### PR TITLE
Added a discord ID field to go to the notifier

### DIFF
--- a/DB/Pilot.cs
+++ b/DB/Pilot.cs
@@ -20,6 +20,8 @@ namespace DB
 
         public string SillyName { get; set; }
 
+        public string DiscordID { get; set; }
+
         public string Aircraft { get; set; }
 
         public string CatchPhrase { get; set; }

--- a/ExternalData/RemoteNotifier.cs
+++ b/ExternalData/RemoteNotifier.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json;
 using RaceLib;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO.Ports;
 using System.Linq;
 using System.Text;

--- a/ExternalData/RemoteNotifier.cs
+++ b/ExternalData/RemoteNotifier.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using RaceLib;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO.Ports;
 using System.Linq;
 using System.Text;
@@ -321,6 +322,7 @@ namespace ExternalData
     {
         public string Name { get; set; }
         public string Phonetic { get; set; }
+        public string DiscordID { get; set; }
         public byte ChannelColorR { get; set; }
         public byte ChannelColorG { get; set; }
         public byte ChannelColorB { get; set; }
@@ -333,6 +335,7 @@ namespace ExternalData
         {
             Name = pc.Pilot.Name;
             Phonetic = pc.Pilot.Phonetic;
+            DiscordID = pc.Pilot.DiscordID;
 
             ChannelColorR = color.R;
             ChannelColorG = color.G;

--- a/RaceLib/Pilot.cs
+++ b/RaceLib/Pilot.cs
@@ -45,6 +45,9 @@ namespace RaceLib
         [Category("Name")]
         public string SillyName { get; set; }
 
+        [Category("Name")]
+        public string DiscordID { get; set; }
+
         [Category("Profile")]
         public string Aircraft { get; set; }
         


### PR DESCRIPTION
Added a discord ID field (to get a users discord id put your discord in developer mode then right click them to copy their user ID):
![image](https://github.com/user-attachments/assets/65fc132b-9c0f-4c7b-a4ce-9465576de9cc)

This allows us to make our notifiers also pass on who's up messages to discord, hopefully making it so people will stop talking and ignore the speaking voice and come to the line when it's their turn
