### PR TITLE
Add support for Chorus32 timer

### DIFF
--- a/Timing/Chorus/ChorusSettings.cs
+++ b/Timing/Chorus/ChorusSettings.cs
@@ -13,6 +13,15 @@ namespace Timing.Chorus
         [Category("Communication")]
         public string ComPort { get; set; }
 
+        [Category("Communication")]
+        public bool UseTCP { get; set; }
+
+        [Category("Communication")]
+        public string IPAddress { get; set; }
+
+        [Category("Communication")]
+        public int Port { get; set; }
+
         public int MinLapTimeSeconds { get; set; }
 
         public int Threshold { get; set; }
@@ -20,10 +29,13 @@ namespace Timing.Chorus
         public ChorusSettings()
         {
             ComPort = "None";
+            UseTCP = false;
+            IPAddress = "192.168.4.1";
+            Port = 9000;
             MinLapTimeSeconds = 0;
             Threshold = 190;
         }
-
+        
 
         public override string ToString()
         {

--- a/Timing/Chorus/ChorusTiming.cs
+++ b/Timing/Chorus/ChorusTiming.cs
@@ -87,9 +87,8 @@ namespace Timing.Chorus
                 comPort.BaudRate = 115200;
                 comPort.RtsEnable = true;
                 comPort.DtrEnable = true;
-                comPort.WriteTimeout = 12000;
-                comPort.ReadTimeout = 500;
-                comPort.Encoding = Encoding.ASCII;
+                comPort.WriteTimeout = 1000;
+                comPort.ReadTimeout = 6000;
 
                 comPort.Open();
 
@@ -174,7 +173,7 @@ namespace Timing.Chorus
                     threshold = (int)(threshold * 1 / frequencySensitivity.SensitivityFactor);
                 }
                 
-                Send(node + "A1*"); // activate the node
+                Send(node + "A1"); // activate the node
                 
                 // Set the frequency. by setting the band and channel
                 //  Send(node + "B" + frequencySensitivity.Band.ToString() + "00"); // TODO: in chours the band is controlled by sending a number and not a letter (AKA R,F,A...), need to make a table for referense 
@@ -190,7 +189,7 @@ namespace Timing.Chorus
             while (index < 8)
             {
                 string node = "R" + index;
-                Send(node + "A0*"); // Deactivate unused nodes
+                Send(node + "A0"); // Deactivate unused nodes
                 index++;
             }
             return true;
@@ -200,13 +199,15 @@ namespace Timing.Chorus
         {
             requestStart = DateTime.Now;
             responseStart = DateTime.Now;
-            return Send("R*R2*");
+            Send("R*R2");
+            return Send("R*R2");
         }
 
 
         public bool EndDetection(EndDetectionType type)
         {
-            return Send("R*R0*");
+            Send("R*R0");
+            return Send("R*R0");
            
         }
 
@@ -263,7 +264,7 @@ namespace Timing.Chorus
             {
                 //Start race confirmed
                 case 'R':
-                    responseStart = DateTime.Now;
+                   // responseStart = DateTime.Now;
                     break;
 
                 // Voltage

--- a/Timing/Chorus/ChorusTiming.cs
+++ b/Timing/Chorus/ChorusTiming.cs
@@ -57,7 +57,7 @@ namespace Timing.Chorus
                 {
                     if (voltage != 0)
                     {
-                        yield return new StatusItem() { StatusOK = voltage > 14, Value = voltage + "v" };
+                        yield return new StatusItem() { StatusOK = voltage > 7, Value = voltage + "v" };
                     }
                 }
                 else
@@ -156,6 +156,7 @@ namespace Timing.Chorus
                 tcpListenerThread.Start();
 
                 Send("N0");
+                Send("R*v");
                 NodeCount = 8;
                 return true;
             }
@@ -282,7 +283,10 @@ namespace Timing.Chorus
             
 
             nodeTofrequency.Clear();
-            //Send("R*I0000");
+            if (rssiRequested) Send("R*I0000");
+
+            // send voltage request
+            //Send("R*v");
             // Set the min laptime on all.
             Send("R*M" + Chorus32Settings.MinLapTimeSeconds.ToString("X2"));
             
@@ -323,13 +327,14 @@ namespace Timing.Chorus
 
                 index++;
             }
-            
+            /*
             while (index < 8)
             {
                 string node = "R" + index;
                 Send(node + "A0"); // Deactivate unused nodes
                 index++;
             }
+            */
             return true;
         }
 
@@ -337,7 +342,6 @@ namespace Timing.Chorus
         {
             requestStart = DateTime.Now;
             responseStart = DateTime.Now;
-            Send("R*R2");
             return Send("R*R2");
         }
 
@@ -364,7 +368,6 @@ namespace Timing.Chorus
         public bool EndDetection(EndDetectionType type)
         {
             rssiRequested = false; // Allow next RSSI request 
-            Send("R*R0");
             return Send("R*R0"); 
         }
 

--- a/Timing/Chorus/ChorusTiming.cs
+++ b/Timing/Chorus/ChorusTiming.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO.Ports;
+using System.Net.Sockets;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -13,6 +15,12 @@ namespace Timing.Chorus
     public class ChorusTiming : ITimingSystem
     {
         private SerialPort comPort;
+        private TcpClient tcpClient;
+        private NetworkStream tcpStream;
+        private StreamReader tcpReader;
+        private StreamWriter tcpWriter;
+        private Thread tcpListenerThread;
+        private bool isDisposing = false;
 
 
         public TimingSystemType Type
@@ -61,6 +69,7 @@ namespace Timing.Chorus
         public ChorusTiming()
         {
             comPort = null;
+            tcpClient = null;
             nodeTofrequency = new Dictionary<int, int>();
         }
 
@@ -81,24 +90,13 @@ namespace Timing.Chorus
         {
             try
             {
-                comPort = new SerialPort();
-                comPort.PortName = Chorus32Settings.ComPort;
-                comPort.DataReceived += ComPort_DataReceived;
-                comPort.BaudRate = 115200;
-                comPort.RtsEnable = true;
-                comPort.DtrEnable = true;
-                comPort.WriteTimeout = 1000;
-                comPort.ReadTimeout = 6000;
-
-                comPort.Open();
-
-                if (comPort.IsOpen)
+                if (Chorus32Settings.UseTCP)
                 {
-                    Connected = true;
-
-                    Send("N");
-                    NodeCount = 8;
-                    return true;
+                    return ConnectTCP();
+                }
+                else
+                {
+                    return ConnectSerial();
                 }
             }
             catch (Exception e)
@@ -106,6 +104,57 @@ namespace Timing.Chorus
                 Connected = false;
                 Logger.TimingLog.LogException(this, e);
                 return false;
+            }
+        }
+
+        private bool ConnectSerial()
+        {
+            comPort = new SerialPort();
+            comPort.PortName = Chorus32Settings.ComPort;
+            comPort.DataReceived += ComPort_DataReceived;
+            comPort.BaudRate = 115200;
+            comPort.RtsEnable = true;
+            comPort.DtrEnable = true;
+            comPort.ReadTimeout = 6000;
+            comPort.WriteTimeout = 12000;
+
+            comPort.Open();
+
+            if (comPort.IsOpen)
+            {
+                Connected = true;
+                Send("N0");
+                NodeCount = 8;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool ConnectTCP()
+        {
+            tcpClient = new TcpClient();
+            tcpClient.Connect(Chorus32Settings.IPAddress, Chorus32Settings.Port);
+
+            if (tcpClient.Connected)
+            {
+                tcpStream = tcpClient.GetStream();
+                tcpReader = new StreamReader(tcpStream, Encoding.ASCII);
+                tcpWriter = new StreamWriter(tcpStream, Encoding.ASCII) { AutoFlush = true };
+
+                Connected = true;
+
+                // Start TCP listener thread  
+                tcpListenerThread = new Thread(TcpDataReceived)
+                {
+                    Name = "Chorus32 TCP Listener",
+                    IsBackground = true
+                };
+                tcpListenerThread.Start();
+
+                Send("N0");
+                NodeCount = 8;
+                return true;
             }
 
             return false;
@@ -130,10 +179,46 @@ namespace Timing.Chorus
             }
         }
 
+        private void TcpDataReceived()
+        {
+            try
+            {
+                while (Connected && !isDisposing && tcpClient.Connected)
+                {
+                    string dataLine = tcpReader.ReadLine();
+                    if (dataLine != null)
+                    {
+                        Parse(dataLine);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (!isDisposing)
+                {
+                    Logger.TimingLog.LogException(this, ex);
+                    Connected = false;
+                }
+            }
+        }
+
         public bool Disconnect()
         {
             Connected = false;
+            isDisposing = true;
 
+            if (Chorus32Settings.UseTCP)
+            {
+                return DisconnectTCP();
+            }
+            else
+            {
+                return DisconnectSerial();
+            }
+        }
+
+        private bool DisconnectSerial()
+        {
             if (comPort == null)
             {
                 return false;
@@ -147,6 +232,39 @@ namespace Timing.Chorus
             }
             comPort = null;
             return false;
+        }
+
+        private bool DisconnectTCP()
+        {
+            bool success = true;
+
+            try
+            {
+                if (tcpListenerThread != null && tcpListenerThread.IsAlive)
+                {
+                    tcpListenerThread.Join(1000);
+                }
+
+                tcpWriter?.Close();
+                tcpReader?.Close();
+                tcpStream?.Close();
+                tcpClient?.Close();
+            }
+            catch (Exception ex)
+            {
+                Logger.TimingLog.LogException(this, ex);
+                success = false;
+            }
+            finally
+            {
+                tcpWriter = null;
+                tcpReader = null;
+                tcpStream = null;
+                tcpClient = null;
+                tcpListenerThread = null;
+            }
+
+            return success;
         }
 
         public void Dispose()
@@ -174,12 +292,20 @@ namespace Timing.Chorus
                 }
                 
                 Send(node + "A1"); // activate the node
-                
+
                 // Set the frequency. by setting the band and channel
-                //  Send(node + "B" + frequencySensitivity.Band.ToString() + "00"); // TODO: in chours the band is controlled by sending a number and not a letter (AKA R,F,A...), need to make a table for referense 
+                // Convert Band enum to numeric value for Chorus32 protocol  
+                int bandValue = GetBandValue(frequencySensitivity.Band);
+
+                // Set the band using B{node}{band} command  
+                Send(node + "B" + bandValue.ToString() + "0");
+
+                // Set the channel using C{node}{channel} command    
                 Send(node + "C" + (frequencySensitivity.Channel - 1).ToString() + "0");
+
+                // Store frequency for detection event mapping  
                 nodeTofrequency.Add(index, frequencySensitivity.Frequency);
-                
+
                 // Set the threshold
                 Send(node + "T" + threshold.ToString("X4"));
 
@@ -203,6 +329,25 @@ namespace Timing.Chorus
             return Send("R*R2");
         }
 
+        private int GetBandValue(string band)
+        {
+            // Map band names to Chorus32 numeric values (0-7) as per protocol spec  
+            switch (band?.ToUpper())
+            {
+                case "RACEBAND": return 0;
+                case "FATSHARK": return 4;
+                case "A": return 1;
+                case "B": return 2;
+                case "E": return 3;
+                case "F":
+                case "AIRWAVE": 
+                case "D":
+                case "LOWBAND": return 5;  // Band D/5.3 is often called LowBand  
+                case "CONNEX": return 6;
+                case "EXTENDED CONNEX": return 7;
+                default: return 0; // Default to Raceband  
+            }
+        }
 
         public bool EndDetection(EndDetectionType type)
         {
@@ -215,14 +360,28 @@ namespace Timing.Chorus
         {
             try
             {
-                comPort.WriteLine(data);
-                return true;
+                if (Chorus32Settings.UseTCP)
+                {
+                    if (tcpWriter != null && tcpClient.Connected)
+                    {
+                        tcpWriter.WriteLine(data);
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (comPort != null && comPort.IsOpen)
+                    {
+                        comPort.WriteLine(data);
+                        return true;
+                    }
+                }
             }
             catch (Exception e)
             {
-                Logger.TimingLog.LogException(this, e);
-                return false;
+                Logger.TimingLog.LogException(this, e);   
             }
+            return false;
         }
 
         private void Parse(string data)
@@ -264,7 +423,7 @@ namespace Timing.Chorus
             {
                 //Start race confirmed
                 case 'R':
-                   // responseStart = DateTime.Now;
+                    responseStart = DateTime.Now;
                     break;
 
                 // Voltage
@@ -274,7 +433,7 @@ namespace Timing.Chorus
                     break;
                 // Lap record
                 case 'L':
-                    int rawMilliseconds = int.Parse(data.Substring(5), System.Globalization.NumberStyles.HexNumber);
+                /*    int rawMilliseconds = int.Parse(data.Substring(5), System.Globalization.NumberStyles.HexNumber);
                     int node = int.Parse(data[1] + "");
 
                     DateTime start = new DateTime((requestStart.Ticks + responseStart.Ticks) / 2);
@@ -286,6 +445,27 @@ namespace Timing.Chorus
                     {
                         OnDetectionEvent?.Invoke(this, frequency, lap, 200);
                     }
+                */
+                    if (data.Length >= 6)
+                    {
+                        int node = int.Parse(data[1].ToString(), System.Globalization.NumberStyles.HexNumber);
+                       
+
+                        if (data.Length >= 12) // Ensure we have enough data for 8-digit hex time  
+                        {
+                            int rawMilliseconds = int.Parse(data.Substring(5), System.Globalization.NumberStyles.HexNumber);
+
+                            DateTime start = new DateTime((requestStart.Ticks + responseStart.Ticks) / 2);
+                            DateTime lap = start.AddMilliseconds(rawMilliseconds);
+
+                            int frequency;
+                            if (nodeTofrequency.TryGetValue(node, out frequency))
+                            {
+                                OnDetectionEvent?.Invoke(this, frequency, lap, 200);
+                            }
+                        }
+                    }
+                
                     break;
 
                 // Min lap time response
@@ -296,6 +476,10 @@ namespace Timing.Chorus
                     break;
                 // Threshold set response
                 case 'T':
+                    break;
+                // RSSI response  
+                case 'r':   
+                    // Handle RSSI data if needed  
                     break;
 
                 default:


### PR DESCRIPTION
changes: 
* Only send a request to change channel on channels changes, now the timer get stuck :) , even in older models. 
* Spectrum analyzer works. 
* Can read Voltage but only send once the request. 
* can change channels
* * only been tested with 4 Pilots ( should go up to 8 ) 

please use this Timing Settings :
use TCP: Yes (checked)
IP: 192.168.4.1
port: 9000
 
 

