### PR TITLE
Resolves issue when you have over 40+ races in a round it starts to miss align the mouse and cuts off the column scroll

### DIFF
--- a/Compositor/Nodes/RenderTargetNode.cs
+++ b/Compositor/Nodes/RenderTargetNode.cs
@@ -48,6 +48,14 @@ namespace Composition.Nodes
         private bool hasLayedOut;
         private Rectangle lastLayoutBounds;
 
+        protected virtual Size MaxRenderTargetSize
+        {
+            get
+            {
+                return new Size(4096, 4096);
+            }
+        }
+
         public ScrollerNode Scroller { get; private set; }
         public Point ScrollOffset
         {
@@ -296,8 +304,9 @@ namespace Composition.Nodes
 
                         Size maxSize = Size;
 
-                        maxSize.Width = Math.Min(4096, maxSize.Width);
-                        maxSize.Height = Math.Min(4096, maxSize.Height);
+                        Size limits = MaxRenderTargetSize;
+                        maxSize.Width = Math.Min(limits.Width, maxSize.Width);
+                        maxSize.Height = Math.Min(limits.Height, maxSize.Height);
 
                         bool isAnimating = false;
                         if (Parent != null && Parent.IsAnimating())

--- a/UI/Nodes/Rounds/EventRoundNode.cs
+++ b/UI/Nodes/Rounds/EventRoundNode.cs
@@ -43,6 +43,24 @@ namespace UI.Nodes.Rounds
 
         public RoundsNode RoundsNode { get; private set; }
 
+        protected override Size MaxRenderTargetSize
+        {
+            get
+            {
+                // Calculate required size dynamically based on number of races
+                // No artificial caps - let the GPU handle its own limits
+                int racesPerColumn = RoundsNode?.RacesPerColumn ?? 3;
+                int raceCount = RaceNodes?.Count() ?? 0;
+                int columns = raceCount > 0 ? (int)Math.Ceiling(raceCount / (float)racesPerColumn) : 1;
+
+                // Estimate width needed per column
+                int estimatedWidthPerColumn = 600;
+                int requiredWidth = columns * estimatedWidthPerColumn;
+
+                return new Size(requiredWidth, 4096);
+            }
+        }
+
         public EventRoundNode(RoundsNode roundsNode, Round round)
             : base(roundsNode.EventManager, round)
         {

--- a/UI/Nodes/Rounds/RoundsNode.cs
+++ b/UI/Nodes/Rounds/RoundsNode.cs
@@ -559,7 +559,7 @@ namespace UI.Nodes.Rounds
 
             Scroller.ViewSizePixels = Bounds.Width;
 
-            Scroller.ContentSizePixels = 100;
+            Scroller.ContentSizePixels = paddingX;
             if (EventXNodes.Any())
             {
                 Scroller.ContentSizePixels += EventXNodes.Select(e => e.Bounds.Right).Max() - EventXNodes.Select(e => e.Bounds.X).Min();


### PR DESCRIPTION
<img width="1580" height="968" alt="Image of the issue with lots of races in round" src="https://github.com/user-attachments/assets/bcb56b68-9cbb-460d-99cb-c53e4a29f0fb" />


