### PR TITLE
Add cross-platform support for event folders and replay detection

### DIFF
--- a/UI/Nodes/Rounds/EventRaceNode.cs
+++ b/UI/Nodes/Rounds/EventRaceNode.cs
@@ -277,7 +277,17 @@ namespace UI.Nodes.Rounds
                 mm.AddSubmenu("Set Race Bracket", SetBracket, Enum.GetValues(typeof(Brackets)).OfType<Brackets>().ToArray());
                 mm.AddItem("Open Race Folder", () =>
                 {
-                    PlatformTools.OpenFileManager(Path.Combine(Directory.GetCurrentDirectory(), "events", EventManager.EventId.ToString(), Race.ID.ToString()));
+                    // Use the same logic as the HTTP service to find the events folder
+                    string eventsPath = ApplicationProfileSettings.Instance.EventStorageLocation;
+                    if (string.IsNullOrEmpty(eventsPath))
+                    {
+                        eventsPath = Path.Combine(IOTools.WorkingDirectory?.FullName ?? "", "events");
+                    }
+                    else if (!Path.IsPathRooted(eventsPath))
+                    {
+                        eventsPath = Path.Combine(IOTools.WorkingDirectory?.FullName ?? "", eventsPath);
+                    }
+                    PlatformTools.OpenFileManager(Path.Combine(eventsPath, EventManager.EventId.ToString(), Race.ID.ToString()));
                 });
                 if (pilot != null)
                 {

--- a/UI/Video/VideoManager.cs
+++ b/UI/Video/VideoManager.cs
@@ -560,8 +560,19 @@ namespace UI.Video
 
                     if (videoInfo != null)
                     {
-                        if (File.Exists(videoInfo.FilePath))
+                        // Extract just the filename, handling both Windows and Mac path separators
+                        string filename = videoInfo.FilePath;
+                        int lastSlash = Math.Max(filename.LastIndexOf('/'), filename.LastIndexOf('\\'));
+                        if (lastSlash >= 0)
                         {
+                            filename = filename.Substring(lastSlash + 1);
+                        }
+
+                        // The video file should be in the race directory
+                        string resolvedPath = Path.Combine(raceDirectory.FullName, filename);
+                        if (File.Exists(resolvedPath))
+                        {
+                            videoInfo.FilePath = resolvedPath;
                             yield return videoInfo.GetVideoConfig();
                         }
                     }


### PR DESCRIPTION
Add support for Mac and Windows folders in debug and when deployed. Allow detection of replay files when in Windows slash format on Mac and vice versa.