### PR TITLE
Small fixes

### DIFF
--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -1735,18 +1735,24 @@ namespace RaceLib
                         int roundNumber = 1;
                         foreach (Round round in roundTypeGroup)
                         {
-                            round.RoundNumber = roundNumber;
-                            db.Update(round);
+                            if (round.RoundNumber != roundNumber)
+                            {
+                                round.RoundNumber = roundNumber;
+                                db.Update(round);
+                            }
 
                             int raceNumber = 1;
 
                             IEnumerable<Race> races = GetRaces(round).OrderBy(r => r.RaceNumber).ThenBy(r => r.Creation);
                             foreach (Race race in races)
                             {
-                                race.RaceNumber = raceNumber;
+                                if (race.RaceNumber != raceNumber)
+                                {
+                                    race.RaceNumber = raceNumber;
+                                    db.Update(race);
+                                }
                                 raceNumber++;
 
-                                db.Update(race);
                             }
                             roundNumber++;
                         }

--- a/UI/Nodes/MenuButton.cs
+++ b/UI/Nodes/MenuButton.cs
@@ -292,6 +292,11 @@ namespace UI.Nodes
                     WorkSet workSet = new WorkSet();
                     eventManager.UnloadRaces(workSet, ll.WorkQueue);
                     eventManager.LoadRaces(workSet, ll.WorkQueue);
+
+                    ll.WorkQueue.Enqueue(workSet, "Refreshing UI", () =>
+                    {
+                        DataDeleted?.Invoke();
+                    });
                 });
             }
             root.AddBlank();

--- a/UI/Nodes/Rounds/EventRaceNode.cs
+++ b/UI/Nodes/Rounds/EventRaceNode.cs
@@ -396,6 +396,7 @@ namespace UI.Nodes.Rounds
                 }
 
                 mm.Show(mouseInputEvent);
+                return true;
             }
 
             bool clicked = false;


### PR DESCRIPTION
here are a couple of small fixes, one for the right click menus opening on top of each other when right clicking on a pilot in a round
<img width="496" height="358" alt="image" src="https://github.com/user-attachments/assets/e523fd89-5ab6-4e6b-b0f8-96c6595f04a4" />

And one that makes the ui update after clicking "Refresh all race data", before if any races were added/removed they would not update in the ui.