### PR TITLE
Fix Mac (arm64) startup crash and fix fpxtrackside webserver not displaying new races.

### DIFF
--- a/ExternalData/ExternalData.csproj
+++ b/ExternalData/ExternalData.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
     <OutputType>Library</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />

--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -976,6 +976,7 @@ namespace RaceLib
             {
                 db.Upsert(race.PilotChannelsSafe);
                 db.Upsert(race);
+                db.Upsert(EventManager.Event);
             }
 
             OnRaceCreated?.Invoke(race);

--- a/Sound/Sound.csproj
+++ b/Sound/Sound.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
     <OutputType>Library</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />

--- a/Spreadsheets/Spreadsheets.csproj
+++ b/Spreadsheets/Spreadsheets.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
     <OutputType>Library</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />

--- a/Timing/Timing.csproj
+++ b/Timing/Timing.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
     <OutputType>Library</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />

--- a/Webb/Webb.csproj
+++ b/Webb/Webb.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
     <OutputType>Library</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />


### PR DESCRIPTION
Mac version was crashing after install and couldnt run it in debug, it was compiling the shared libs as x64.

There is also a fix for in RaceLib/RaceManager.cs which has been broken for while it was stopping the webserver updating   when new races added. It looks like it was introduced in this commit 72824ab5 Oct 21, 2025 13:43. I was trying to get robo's drone dashboard working and it was not updating looks like this has solved it for me. The new races are now appearing on the webserver after this change and so data now gets to the drone dashboard.

