### PR TITLE
ArUco: fix Hybrid override, add overlay marker hold and detection FPS…

### DIFF
--- a/Timing/Aruco/ArucoTimingSettings.cs
+++ b/Timing/Aruco/ArucoTimingSettings.cs
@@ -81,6 +81,11 @@ namespace Timing.Aruco
         [Description("Draw the marker area as a percentage of the detection frame.")]
         public bool ShowMarkerSizePercent { get; set; }
 
+        [Category("Overlay")]
+        [DisplayName("Show Detection FPS")]
+        [Description("Draw the ArUco detection thread's iterations-per-second on each channel's overlay.")]
+        public bool ShowFps { get; set; }
+
         public ArucoTimingSettings()
         {
             MarkerIds = "0";
@@ -94,6 +99,7 @@ namespace Timing.Aruco
             ShowMarkerBox = true;
             ShowMarkerId = true;
             ShowMarkerSizePercent = true;
+            ShowFps = false;
         }
 
         public override string ToString()

--- a/UI/Video/ArucoFrameOverlay.cs
+++ b/UI/Video/ArucoFrameOverlay.cs
@@ -34,11 +34,35 @@ namespace UI.Video
             public bool MirrorX;
         }
 
+        /// <summary>
+        /// How long (ms) a marker keeps being drawn after its last detection. Bridges 1-frame
+        /// detection misses (avoids overlay flicker) while still erasing the box once the marker
+        /// truly leaves the scene or the detection thread stalls.
+        /// </summary>
+        public const int OverlayHoldMs = 150;
+
+        private struct HeldMarker
+        {
+            public MarkerDetection Detection;
+            public DateTime SeenAt;
+        }
+
+        /// <summary>
+        /// Per-channel state: latest geometry (crop/flip/mirror/sizes) plus a per-marker-ID
+        /// dictionary of the most recent detection and when it was seen. Aging out markers by ID
+        /// rather than by whole-frame lets a brief miss on one of N markers preserve the others.
+        /// </summary>
+        private sealed class ChannelEntry
+        {
+            public Cached Geometry;
+            public readonly Dictionary<int, HeldMarker> Markers = new Dictionary<int, HeldMarker>();
+        }
+
         // Multiple channels can share the same FrameSource (e.g. a single 2x2 capture split
         // by RelativeSourceBounds into 4 pilot views). We therefore index first by FrameSource
         // then by an opaque channel key so each channel's crop is remembered independently.
-        private static readonly ConcurrentDictionary<ImageServer.FrameSource, ConcurrentDictionary<object, Cached>> cache
-            = new ConcurrentDictionary<ImageServer.FrameSource, ConcurrentDictionary<object, Cached>>();
+        private static readonly ConcurrentDictionary<ImageServer.FrameSource, ConcurrentDictionary<object, ChannelEntry>> cache
+            = new ConcurrentDictionary<ImageServer.FrameSource, ConcurrentDictionary<object, ChannelEntry>>();
 
         private static volatile bool registered;
         private static readonly object registerLock = new object();
@@ -46,7 +70,14 @@ namespace UI.Video
         public static volatile bool ShowBox = true;
         public static volatile bool ShowId = true;
         public static volatile bool ShowSizePercent = true;
+        public static volatile bool ShowFps = false;
         public static volatile bool Enabled = false;
+
+        /// <summary>
+        /// Latest detection iterations per second, published by <see cref="UI.Video.ArucoTimingManager"/>
+        /// once per ~1 s. Drawn in each channel's overlay when <see cref="ShowFps"/> is on.
+        /// </summary>
+        public static volatile float DetectionFps = 0f;
 
         public static void EnsureRegistered()
         {
@@ -68,28 +99,79 @@ namespace UI.Video
         public static void SetLatestDetections(ImageServer.FrameSource source, object channelKey, Cached cached)
         {
             if (source == null || channelKey == null || cached == null) return;
-            var inner = cache.GetOrAdd(source, _ => new ConcurrentDictionary<object, Cached>());
-            inner[channelKey] = cached;
+            var inner = cache.GetOrAdd(source, _ => new ConcurrentDictionary<object, ChannelEntry>());
+            var entry = inner.GetOrAdd(channelKey, _ => new ChannelEntry());
+
+            entry.Geometry = cached;
+
+            DateTime now = DateTime.UtcNow;
+            lock (entry.Markers)
+            {
+                if (cached.Detections != null)
+                {
+                    foreach (var d in cached.Detections)
+                    {
+                        if (d == null || d.Corners == null) continue;
+                        entry.Markers[d.Id] = new HeldMarker { Detection = d, SeenAt = now };
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Snapshot the held markers for a channel, dropping anything older than <see cref="OverlayHoldMs"/>.
+        /// Returns null when nothing should be drawn.
+        /// </summary>
+        private static List<MarkerDetection> CollectActive(ChannelEntry entry, DateTime now)
+        {
+            List<MarkerDetection> active = null;
+            List<int> expired = null;
+            lock (entry.Markers)
+            {
+                foreach (var kv in entry.Markers)
+                {
+                    double ageMs = (now - kv.Value.SeenAt).TotalMilliseconds;
+                    if (ageMs > OverlayHoldMs)
+                    {
+                        if (expired == null) expired = new List<int>();
+                        expired.Add(kv.Key);
+                    }
+                    else
+                    {
+                        if (active == null) active = new List<MarkerDetection>();
+                        active.Add(kv.Value.Detection);
+                    }
+                }
+                if (expired != null)
+                {
+                    foreach (var k in expired) entry.Markers.Remove(k);
+                }
+            }
+            return active;
         }
 
         private static void OnBeforeFrame(ImageServer.FrameSource source, byte[] buffer)
         {
             if (!Enabled || buffer == null) return;
-            if (!(ShowBox || ShowId || ShowSizePercent)) return;
+            if (!(ShowBox || ShowId || ShowSizePercent || ShowFps)) return;
 
             int w = source.FrameWidth;
             int h = source.FrameHeight;
             if (w <= 0 || h <= 0 || buffer.Length < w * h * 4) return;
             if (!cache.TryGetValue(source, out var inner) || inner.IsEmpty) return;
 
+            DateTime now = DateTime.UtcNow;
             GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
             try
             {
                 IntPtr data = handle.AddrOfPinnedObject();
-                foreach (var cached in inner.Values)
+                foreach (var entry in inner.Values)
                 {
-                    if (cached?.Detections == null || cached.Detections.Count == 0) continue;
-                    DrawInto(data, w, h, source.FrameFormat, cached);
+                    if (entry?.Geometry == null) continue;
+                    var active = CollectActive(entry, now);
+                    bool hasMarkers = active != null && active.Count > 0;
+                    if (!hasMarkers && !ShowFps) continue;
+                    DrawInto(data, w, h, source.FrameFormat, entry.Geometry, active);
                 }
             }
             finally
@@ -101,21 +183,25 @@ namespace UI.Video
         private static void OnBeforeFramePtr(ImageServer.FrameSource source, IntPtr buffer, int length)
         {
             if (!Enabled || buffer == IntPtr.Zero) return;
-            if (!(ShowBox || ShowId || ShowSizePercent)) return;
+            if (!(ShowBox || ShowId || ShowSizePercent || ShowFps)) return;
 
             int w = source.FrameWidth;
             int h = source.FrameHeight;
             if (w <= 0 || h <= 0 || length < w * h * 4) return;
             if (!cache.TryGetValue(source, out var inner) || inner.IsEmpty) return;
 
-            foreach (var cached in inner.Values)
+            DateTime now = DateTime.UtcNow;
+            foreach (var entry in inner.Values)
             {
-                if (cached?.Detections == null || cached.Detections.Count == 0) continue;
-                DrawInto(buffer, w, h, source.FrameFormat, cached);
+                if (entry?.Geometry == null) continue;
+                var active = CollectActive(entry, now);
+                bool hasMarkers = active != null && active.Count > 0;
+                if (!hasMarkers && !ShowFps) continue;
+                DrawInto(buffer, w, h, source.FrameFormat, entry.Geometry, active);
             }
         }
 
-        private static void DrawInto(IntPtr data, int w, int h, SurfaceFormat format, Cached cached)
+        private static void DrawInto(IntPtr data, int w, int h, SurfaceFormat format, Cached cached, List<MarkerDetection> detections)
         {
             // Map from detection (480x360) → source-pixel coords within the crop rectangle.
             double cropX = cached.CropRelX * w;
@@ -137,7 +223,28 @@ namespace UI.Video
                 {
                     double detArea = (double)cached.DetectionWidth * cached.DetectionHeight;
 
-                    foreach (var d in cached.Detections)
+                    if (ShowFps)
+                    {
+                        // Bottom-left of the channel's crop. Yellow with black outline for
+                        // legibility against any feed colour. Mirror/flip applied so the text
+                        // stays at the channel's visual bottom-left after burn-in.
+                        string fpsText = DetectionFps.ToString("F0") + " fps";
+                        double fxBase = cropX + 6;
+                        double fyBase = cropY + cropH - 6;  // baseline near crop bottom
+                        if (cached.MirrorX) fxBase = w - 1 - fxBase;
+                        if (cached.FlipY)   fyBase = h - 1 - fyBase;
+                        Scalar fpsColor = format == SurfaceFormat.Color
+                            ? new Scalar(255, 255, 0, 255)   // RGBA: yellow
+                            : new Scalar(0, 255, 255, 255);  // BGRA: yellow
+                        var fpsOrg = new Point((int)fxBase, (int)fyBase);
+                        // Outline pass for contrast.
+                        Cv2.PutText(mat, fpsText, fpsOrg, HersheyFonts.HersheySimplex, fontScale * 1.2, Scalar.Black, textThickness + 2, LineTypes.AntiAlias);
+                        Cv2.PutText(mat, fpsText, fpsOrg, HersheyFonts.HersheySimplex, fontScale * 1.2, fpsColor, textThickness, LineTypes.AntiAlias);
+                    }
+
+                    if (detections == null) return;
+
+                    foreach (var d in detections)
                     {
                         if (d.Corners == null || d.Corners.Length < 3) continue;
 

--- a/UI/Video/ArucoTimingManager.cs
+++ b/UI/Video/ArucoTimingManager.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -138,6 +139,11 @@ namespace UI.Video
                 var sizedNodes = new HashSet<ChannelVideoNode>();
                 long lastFrame = -1;
 
+                // Detection FPS publishing for the optional overlay readout. Recomputed every ~1s
+                // from the iteration count; the overlay reads the latest value via ArucoFrameOverlay.
+                var fpsSw = Stopwatch.StartNew();
+                int fpsIter = 0;
+
                 while (run)
                 {
                     var systems = timingSystemManager.TimingSystems
@@ -194,20 +200,6 @@ namespace UI.Video
 
                     DateTime captureTime = DateTime.Now;
 
-                    // Detector parameters are shared: take the widest (most tolerant) setting
-                    // across all ArucoTimingSystem instances so one detection pass serves all.
-                    ArucoDetectMode sharedMode = ArucoDetectMode.Original;
-                    double sharedEcRate = 0.0;
-                    int sharedHybridDist = 0;
-                    foreach (var sys in systems)
-                    {
-                        var s = sys.ArucoSettings;
-                        if (s == null) continue;
-                        if ((int)s.DetectMode > (int)sharedMode) sharedMode = s.DetectMode;
-                        if (s.ErrorCorrectionRate > sharedEcRate) sharedEcRate = s.ErrorCorrectionRate;
-                        if (s.HybridDistanceThreshold > sharedHybridDist) sharedHybridDist = s.HybridDistanceThreshold;
-                    }
-
                     // Reference settings: Primary's if one exists, otherwise the first Split.
                     // All other instances inherit shared thresholds from the reference so the
                     // per-instance UI can stay limited to MarkerIds.
@@ -220,12 +212,21 @@ namespace UI.Video
                             .Select(sys => sys.ArucoSettings)
                             .FirstOrDefault();
 
+                    // Detector parameters are shared from the reference (Primary). Splits do not
+                    // expose DetectMode in their UI, so their stored value (default Hybrid) must
+                    // not influence the single detection pass — otherwise changing the Primary's
+                    // mode away from Hybrid would have no effect.
+                    ArucoDetectMode sharedMode = primarySettings?.DetectMode ?? ArucoDetectMode.Original;
+                    double sharedEcRate = primarySettings?.ErrorCorrectionRate ?? 0.0;
+                    int sharedHybridDist = primarySettings?.HybridDistanceThreshold ?? 0;
+
                     // Overlay display flags track the Primary's settings.
                     if (primarySettings != null)
                     {
                         ArucoFrameOverlay.ShowBox = primarySettings.ShowMarkerBox;
                         ArucoFrameOverlay.ShowId = primarySettings.ShowMarkerId;
                         ArucoFrameOverlay.ShowSizePercent = primarySettings.ShowMarkerSizePercent;
+                        ArucoFrameOverlay.ShowFps = primarySettings.ShowFps;
                     }
                     bool multiThread = primarySettings?.UseMultiThreadDetection ?? true;
 
@@ -343,6 +344,14 @@ namespace UI.Video
                             sys.ReportMarkerCount(cvn.Channel.Frequency, matching, (int)maxArea, captureTime,
                                 effective.MarkerThreshold, effective.FlickerLengthMs);
                         }
+                    }
+
+                    fpsIter++;
+                    if (fpsSw.ElapsedMilliseconds >= 1000)
+                    {
+                        ArucoFrameOverlay.DetectionFps = (float)(fpsIter * 1000.0 / fpsSw.Elapsed.TotalMilliseconds);
+                        fpsIter = 0;
+                        fpsSw.Restart();
                     }
                 }
             }


### PR DESCRIPTION
ArucoTimingManager:
Changed the behavior so that sharedMode, EcRate, and HybridDist are derived from the primary reference settings, rather than simply adopting the highest value across the entire system (bug). In the previous implementation, the default DetectMode for Splits remained set to Hybrid, so Hybrid was enforced even when the primary was set to Original or Corrected. This change ensures that the Original, Corrected, and Hybrid settings are now applied correctly.

ArucoFrameOverlay: 
Fixed a bug where detected markers would occasionally remain on screen indefinitely. Each marker ID is now tracked individually using the SeenAt timestamp. Entries older than OverlayHoldMs (150 ms) are discarded during rendering. The box is reliably cleared when a marker actually leaves the frame.

ArucoTimingManager + ArucoFrameOverlay + ArucoTimingSettings:
Added the optional “Show Detection FPS” overlay flag. ArucoTimingManager publishes the number of iterations per second of the detection thread every second. When this flag is enabled, the overlay displays that value in the bottom-left corner of each channel’s cropped area.
This makes it easier for users to decide whether to use Hybrid or Original/Collected based on their PC’s performance.