### PR TITLE
Add 8/5/4/3/2/1 second countdown sounds before race start

### DIFF
--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -31,6 +31,7 @@ namespace RaceLib
         public event Race.OnRaceEvent OnRaceCreated;
         public event Race.OnRaceEvent OnRaceStart;
         public event Race.OnRaceEvent OnRacePreStart;
+        public event Action<Race, DateTime> OnRaceStartScheduled;
         public event Race.OnRaceEvent OnRaceChanged;
         public event Race.OnRaceEvent OnRaceResumed;
         public event Race.OnRaceEvent OnRacePilotsSet;
@@ -746,6 +747,8 @@ namespace RaceLib
                     return false;
                 }
             }
+
+            OnRaceStartScheduled?.Invoke(currentRace, startTime);
 
             while (PreRaceStartDelay && DateTime.Now < startTime)
             {

--- a/Sound/Sound.cs
+++ b/Sound/Sound.cs
@@ -14,6 +14,12 @@ namespace Sound
     {
         None,
         StartRaceIn,
+        StartRaceIn8,
+        StartRaceIn5,
+        StartRaceIn4,
+        StartRaceIn3,
+        StartRaceIn2,
+        StartRaceIn1,
         RaceStart,
         RaceOver,
         RaceResumed,

--- a/Sound/SoundManager.cs
+++ b/Sound/SoundManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Tools;
 using Composition;
 using RaceLib.Game;
@@ -96,6 +97,18 @@ namespace Sound
         private WorkQueue backgroundQueue;
         private bool backgroundQueueStopping;
 
+        private CancellationTokenSource startCountdownCts;
+
+        private static readonly (int seconds, SoundKey key)[] StartCountdownSchedule =
+        {
+            (8, SoundKey.StartRaceIn8),
+            (5, SoundKey.StartRaceIn5),
+            (4, SoundKey.StartRaceIn4),
+            (3, SoundKey.StartRaceIn3),
+            (2, SoundKey.StartRaceIn2),
+            (1, SoundKey.StartRaceIn1),
+        };
+
         public SoundManager(EventManager eventManager, Profile profile)
         {
             this.eventManager = eventManager;
@@ -120,6 +133,7 @@ namespace Sound
             if (em != null)
             {
                 em.RaceManager.OnRaceStart += RaceManager_OnRaceStart;
+                em.RaceManager.OnRaceStartScheduled += RaceManager_OnRaceStartScheduled;
                 em.RaceManager.OnRaceEnd += RaceOver;
                 em.RaceManager.OnLapDetected += Lap;
                 em.RaceManager.OnSplitDetection += Sector;
@@ -145,6 +159,9 @@ namespace Sound
         {
             StopSound();
 
+            startCountdownCts?.Dispose();
+            startCountdownCts = null;
+
             backgroundQueue?.Dispose();
             backgroundQueue = null;
 
@@ -152,6 +169,7 @@ namespace Sound
             if (em != null)
             {
                 em.RaceManager.OnRaceStart -= RaceManager_OnRaceStart;
+                em.RaceManager.OnRaceStartScheduled -= RaceManager_OnRaceStartScheduled;
                 em.RaceManager.OnRaceEnd -= RaceOver;
                 em.RaceManager.OnLapDetected -= Lap;
                 em.RaceManager.OnSplitDetection -= Sector;
@@ -232,6 +250,12 @@ namespace Sound
                 Sound[] defaultSounds = new Sound[]
                 {
                     new Sound() { Key = SoundKey.StartRaceIn, TextToSpeech = "Arm your quads. Starting on the tone in less than {time}", Category = Sound.SoundCategories.Race },
+                    new Sound() { Key = SoundKey.StartRaceIn8, TextToSpeech = "8 seconds", Enabled = false, Category = Sound.SoundCategories.Race },
+                    new Sound() { Key = SoundKey.StartRaceIn5, TextToSpeech = "5", Enabled = false, Category = Sound.SoundCategories.Race },
+                    new Sound() { Key = SoundKey.StartRaceIn4, TextToSpeech = "4", Enabled = false, Category = Sound.SoundCategories.Race },
+                    new Sound() { Key = SoundKey.StartRaceIn3, TextToSpeech = "3", Enabled = false, Category = Sound.SoundCategories.Race },
+                    new Sound() { Key = SoundKey.StartRaceIn2, TextToSpeech = "2", Enabled = false, Category = Sound.SoundCategories.Race },
+                    new Sound() { Key = SoundKey.StartRaceIn1, TextToSpeech = "1", Enabled = false, Category = Sound.SoundCategories.Race },
                     new Sound() { Key = SoundKey.RaceStart, TextToSpeech = "Go", Filename = @"sounds/tone.wav", Category = Sound.SoundCategories.Race },
                     new Sound() { Key = SoundKey.RaceOver, TextToSpeech = "Race over", Category = Sound.SoundCategories.Race },
                     new Sound() { Key = SoundKey.RaceResumed, TextToSpeech = "Race Resumed", Category = Sound.SoundCategories.Race },
@@ -393,6 +417,34 @@ namespace Sound
             if (!eventManager.RaceManager.StaggeredStart)
             {
                 Start();
+            }
+        }
+
+        private void RaceManager_OnRaceStartScheduled(Race race, DateTime startTime)
+        {
+            startCountdownCts?.Cancel();
+            startCountdownCts?.Dispose();
+            startCountdownCts = new CancellationTokenSource();
+            CancellationToken token = startCountdownCts.Token;
+
+            foreach ((int seconds, SoundKey key) in StartCountdownSchedule)
+            {
+                DateTime fireAt = startTime - TimeSpan.FromSeconds(seconds);
+                TimeSpan delay = fireAt - DateTime.Now;
+                if (delay <= TimeSpan.Zero)
+                    continue;
+
+                SoundKey capturedKey = key;
+                Task.Delay(delay, token).ContinueWith(t =>
+                {
+                    if (t.IsCanceled)
+                        return;
+
+                    SpeechParameters parameters = new SpeechParameters();
+                    parameters.Priority = 9500;
+                    parameters.SecondsExpiry = 1;
+                    PlaySound(capturedKey, parameters);
+                }, TaskScheduler.Default);
             }
         }
 
@@ -661,6 +713,7 @@ namespace Sound
         public void StopSound()
         {
             backgroundQueueStopping = true;
+            startCountdownCts?.Cancel();
             speechManager?.StopSpeech();
         }
 

--- a/Sound/SoundManager.cs
+++ b/Sound/SoundManager.cs
@@ -422,11 +422,14 @@ namespace Sound
 
         private void RaceManager_OnRaceStartScheduled(Race race, DateTime startTime)
         {
-            startCountdownCts?.Cancel();
-            startCountdownCts?.Dispose();
+            // Swap in the new CTS before cancelling the old one — StopSound can be called
+            // from another thread at any time, so the field must never point to a disposed object.
+            CancellationTokenSource oldCts = startCountdownCts;
             startCountdownCts = new CancellationTokenSource();
-            CancellationToken token = startCountdownCts.Token;
+            oldCts?.Cancel();
+            oldCts?.Dispose();
 
+            CancellationToken token = startCountdownCts.Token;
             foreach ((int seconds, SoundKey key) in StartCountdownSchedule)
             {
                 DateTime fireAt = startTime - TimeSpan.FromSeconds(seconds);


### PR DESCRIPTION
## Motivation
https://www.youtube.com/watch?v=iVOGKqFkjV4

  In the Japanese Whoop racing scene, a fixed countdown start (e.g. an
  announcer calling "Get Ready... 5, 4, 3, 2, 1, GO") is the standard
  race-start convention. FPVTrackside currently assumes a randomized start
  delay between `MinStartDelay` and `MaxStartDelay`. Until now, to realise
  countdown-style announcements, we have relied on an external ArUco-marker
  detection system (TVPAS) that consumes RotorHazard-compatible start-time
  synchronization data, but the external detection system is no longer
  required, so this needs to be handled inside FPVTrackside itself.

  This pull request adds optional countdown sounds that play at fixed offsets
  (8s, 5s, 4s, 3s, 2s, 1s) before the actual start tone. By setting
  `MinStartDelay = MaxStartDelay >= 10s` and turning `StartRaceIn` off,
  organisers can reliably run countdown starts without any external tools.



  ## What this changes

  ### `RaceLib/RaceManager.cs`
  - New event `OnRaceStartScheduled(Race, DateTime startTime)` fired inside
    `StartRaceInLessThan` after the start time is finalized but before the
    pre-start wait loop. This lets subscribers know exactly when the start
    tone will sound.

  ### `Sound/Sound.cs`
  - 6 new `SoundKey` values: `StartRaceIn8`, `StartRaceIn5`, `StartRaceIn4`,
    `StartRaceIn3`, `StartRaceIn2`, `StartRaceIn1`.

  ### `Sound/SoundManager.cs`
  - 6 new default `Sound` entries (TTS "8 seconds", "5", "4", "3", "2", "1"),
    defaulted to `Enabled = false` so existing users see no behaviour change.
  - Subscribes to `OnRaceStartScheduled` and schedules each countdown via
    `Task.Delay` relative to the actual start time.
  - All scheduled countdowns are cancelled by a single `Cancel` inside
    `StopSound` (and therefore on race cancel / timing-system failure /
    emergency stop).