### PR TITLE
 Fix ArUco lap time inflated by flicker debounce

### DIFF
--- a/Timing/Aruco/ArucoTimingSystem.cs
+++ b/Timing/Aruco/ArucoTimingSystem.cs
@@ -137,7 +137,8 @@ namespace Timing.Aruco
 
             if (captureTime >= state.FlickerEndTime)
             {
-                OnDetectionEvent?.Invoke(this, frequency, captureTime, state.LastPeak);
+                DateTime detectionTime = captureTime.AddMilliseconds(-flickerLengthMs);
+                OnDetectionEvent?.Invoke(this, frequency, detectionTime, state.LastPeak);
                 state.InGate = false;
                 state.FlickerEndTime = DateTime.MinValue;
             }


### PR DESCRIPTION
  Summary

  - ArucoTimingSystem.ReportMarkerCount was reporting the detection time at the moment the flicker debounce timer
  expired, which added flickerLengthMs of latency to every lap.
  - The flicker window is purely a debounce to confirm the marker has truly left the frame — it shouldn't be counted as
  part of the gate passage.
  - Subtracting flickerLengthMs from captureTime when invoking OnDetectionEvent makes the reported time correspond to
  the moment markers were last observed (i.e. gate exit).

  Why this matters

  - Increasing Flicker Length to be more tolerant of brief detection misses currently shifts every recorded lap later by
   the same amount, so users have to choose between robust detection and accurate timing.
  - After this fix, Flicker Length behaves as a true debounce — tuning it changes only the noise tolerance, not the
  recorded lap time.
  - Race-length validity logic (RaceManager.OnDetection → last.EndRaceTime > RaceLength) is also based on
  detection.Time, so a pilot crossing within the time limit will now be recorded with a Time that actually falls within
  the limit.

  Behavior with mid-flicker re-detections

  Each count >= markerThreshold frame resets state.FlickerEndTime to DateTime.MinValue, so the timer restarts from the
  last observed loss-of-marker. The corrected captureTime - flickerLengthMs therefore points to the final marker-loss
  moment of the passage — flickers are still merged into a single detection, just with the correct timestamp.