### PR TITLE
Fix Refresh all race data not updating laps in UI

### DIFF
--- a/UI/Nodes/Rounds/EventRaceNode.cs
+++ b/UI/Nodes/Rounds/EventRaceNode.cs
@@ -18,7 +18,7 @@ namespace UI.Nodes.Rounds
 {
     public class EventRaceNode : AspectNode
     {
-        public Race Race { get; private set; }
+        public Race Race { get; internal set; }
 
         public EventManager EventManager { get; private set; }
 

--- a/UI/Nodes/Rounds/EventRoundNode.cs
+++ b/UI/Nodes/Rounds/EventRoundNode.cs
@@ -188,6 +188,10 @@ namespace UI.Nodes.Rounds
                     rn.NeedFullRefresh += () => { Refresh(true); };
                     contentContainer.AddChild(rn);
                 }
+                else
+                {
+                    rn.Race = race;
+                }
 
                 // Sync the in memory round objects..
                 race.Round = Round;


### PR DESCRIPTION
When races are reloaded from disk, EventRoundNode.SetRaces() matched existing EventRaceNode objects by Race ID but never updated their Race reference to the new instance. This caused Init() to read stale data, so externally modified laps were not reflected in the UI after refresh.

This change allows for external DVR reviews of race data to be saved back to the main instance of FPV Trackside. 