### PR TITLE
ArUco overlay orientation fixes across capture backends

### DIFF
--- a/UI/Video/ArucoFrameOverlay.cs
+++ b/UI/Video/ArucoFrameOverlay.cs
@@ -237,9 +237,12 @@ namespace UI.Video
                             ? new Scalar(255, 255, 0, 255)   // RGBA: yellow
                             : new Scalar(0, 255, 255, 255);  // BGRA: yellow
                         var fpsOrg = new Point((int)fxBase, (int)fyBase);
-                        // Outline pass for contrast.
-                        Cv2.PutText(mat, fpsText, fpsOrg, HersheyFonts.HersheySimplex, fontScale * 1.2, Scalar.Black, textThickness + 2, LineTypes.AntiAlias);
-                        Cv2.PutText(mat, fpsText, fpsOrg, HersheyFonts.HersheySimplex, fontScale * 1.2, fpsColor, textThickness, LineTypes.AntiAlias);
+                        // bottomLeftOrigin flips glyph rows so text is upright when the buffer
+                        // is bottom-up DIB (DirectShow / MediaFoundation) — points map fine via
+                        // FlipY, but PutText writes glyphs top-down by default and would appear
+                        // upside-down on screen for a bottom-up buffer.
+                        Cv2.PutText(mat, fpsText, fpsOrg, HersheyFonts.HersheySimplex, fontScale * 1.2, Scalar.Black, textThickness + 2, LineTypes.AntiAlias, cached.FlipY);
+                        Cv2.PutText(mat, fpsText, fpsOrg, HersheyFonts.HersheySimplex, fontScale * 1.2, fpsColor, textThickness, LineTypes.AntiAlias, cached.FlipY);
                     }
 
                     if (detections == null) return;
@@ -295,8 +298,13 @@ namespace UI.Video
 
                         if (label != null)
                         {
-                            var org = new Point((int)acx, (int)acy - 10);
-                            Cv2.PutText(mat, label, org, HersheyFonts.HersheySimplex, fontScale, color, textThickness, LineTypes.AntiAlias);
+                            // For a bottom-up buffer the label sits visually above the marker
+                            // when its origin is BELOW the marker centre (because rows are
+                            // inverted). Mirror the +/- offset alongside passing FlipY to the
+                            // PutText origin flag so glyphs render upright.
+                            int yOffset = cached.FlipY ? +10 : -10;
+                            var org = new Point((int)acx, (int)acy + yOffset);
+                            Cv2.PutText(mat, label, org, HersheyFonts.HersheySimplex, fontScale, color, textThickness, LineTypes.AntiAlias, cached.FlipY);
                         }
                     }
                 }

--- a/WindowsMediaPlatform/DirectShow/DirectShowDeviceFrameSource.cs
+++ b/WindowsMediaPlatform/DirectShow/DirectShowDeviceFrameSource.cs
@@ -294,7 +294,13 @@ namespace WindowsMediaPlatform.DirectShow
                 }
                 DsUtils.FreeAMMediaType(ammediaType);
 
-                Direction = MediaFoundation.MFHelper.GetDirection(SubType);
+                // DirectShow's sample grabber is configured (in DirectShowFrameSource.Setup)
+                // to deliver RGB32 regardless of the device's native subtype, and DirectShow
+                // RGB32 follows the DIB convention (bottom-up in memory). The renderer flips Y
+                // when Direction == TopDown, which is exactly what's needed to display upright.
+                // Using GetDirection(SubType) made YUY2/RGB-native inputs render upside-down
+                // because those subtypes resolve to BottomUp.
+                Direction = Directions.TopDown;
 
                 return result;
             }

--- a/WindowsMediaPlatform/MediaFoundation/MediaFoundationFrameSource.cs
+++ b/WindowsMediaPlatform/MediaFoundation/MediaFoundationFrameSource.cs
@@ -364,16 +364,12 @@ namespace WindowsMediaPlatform.MediaFoundation
                 MFError.ThrowExceptionForHR(hr);
 
 
-                int stride = MFExtern.MFGetAttributeUINT32(outputType, MFAttributesClsid.MF_MT_DEFAULT_STRIDE, 0);
-
-                if (stride != 0) 
-                {
-                    Direction = stride < 0 ? Directions.TopDown : Directions.BottomUp;
-                }
-                else
-                {
-                    Direction = MFHelper.GetDirection(outputSubType);
-                }
+                // MF buffers reach the renderer with bottom-up byte ordering on the devices
+                // tested here (e.g. NV12 reports stride>0, which the spec calls top-down, yet
+                // the actual rows arrive bottom-up). Flag TopDown so FrameNode.Flip() flips Y,
+                // matching the DirectShow path and giving an upright image. FFmpeg, which truly
+                // emits top-down RGBA, sets BottomUp itself.
+                Direction = Directions.TopDown;
 
                 string format = MFHelper.GetFormat(currentSubType);
                 Tools.Logger.VideoLog.Log(this, VideoConfig.DeviceName, "Width: " + width + " Height: " + height + " Format: " + format);


### PR DESCRIPTION
## Summary

  Three small fixes that together make the ArUco overlay (live + recorded
  replay) render upright across every capture backend.

  - **DirectShow capture**: pin `Direction = TopDown`. The sample grabber
    is forced to deliver RGB32 (bottom-up DIB) regardless of the device's
    native subtype, so deriving `Direction` from the input subtype made
    YUY2 / RGB-classified inputs render upside-down via `FrameNode.Flip()`.
  - **MediaFoundation capture**: pin `Direction = TopDown`. The previous
    `MF_MT_DEFAULT_STRIDE` / `MFHelper.GetDirection` logic flagged NV12
    as top-down (stride > 0) but the rows actually arrived bottom-up on
    the devices tested, so the renderer skipped its Y flip.
  - **ArUco overlay**: pass `FlipY` to `Cv2.PutText`'s `bottomLeftOrigin`
    parameter on every label/FPS draw, and flip the "above the marker"
    Y offset (`-10` vs `+10`). Without this, on a bottom-up buffer the
    polyline box sat correctly (lines are direction-symmetric) while the
    ID / size labels and FPS readout came out upside-down.

  FFmpeg (top-down RGBA, `Direction = BottomUp`, `FlipY = false`) is
  unchanged and continues to render correctly.

  ## Why

  `FrameNode.Flip()` flips the source rectangle's Y when
  `Source.Direction == TopDown`. That single signal also drives the ArUco
  overlay's `FlipY`, which the burn-in path uses to map detection
  coordinates back to the raw frame buffer's row order. So one consistent
  orientation flag per backend keeps the renderer, the on-screen overlay,
  and the recorded burn-in all aligned.

  The two capture-backend changes pick the value empirically from real
  hardware rather than from a per-subtype table that didn't match
  observed behaviour.