### PR TITLE
Handicap races

### DIFF
--- a/DB/JSON/JsonDatabase.cs
+++ b/DB/JSON/JsonDatabase.cs
@@ -125,7 +125,7 @@ namespace DB.JSON
             if (typeof(T) == typeof(RaceLib.Track))
                 return new ConvertedCollection<RaceLib.Track, Track>(Tracks, this) as IDatabaseCollection<T>;
 
-            if (typeof(T) == typeof(RaceLib.PilotChannel))
+            if (typeof(RaceLib.PilotChannel).IsAssignableFrom(typeof(T)))
                 return new DummyCollection<T>();
 
             if (typeof(T) == typeof(RaceLib.Lap))

--- a/DB/JSON/PilotChannel.cs
+++ b/DB/JSON/PilotChannel.cs
@@ -13,7 +13,6 @@ namespace DB.JSON
 
         public Guid Channel { get; set; }
 
-
         public PilotChannel() { }
 
         public PilotChannel(RaceLib.PilotChannel obj)
@@ -32,6 +31,38 @@ namespace DB.JSON
             pilotChannel.Pilot = Pilot.Convert<RaceLib.Pilot>(database);
             pilotChannel.Channel = Channel.Convert<RaceLib.Channel>(database);
             return pilotChannel;
+        }
+    }
+
+    public class RacePilotChannel : DatabaseObjectT<RaceLib.RacePilotChannel>
+    {
+        public Guid Pilot { get; set; }
+
+        public Guid Channel { get; set; }
+
+        public TimeSpan HandicapOffset { get; set; }
+
+        public RacePilotChannel() { }
+
+        public RacePilotChannel(RaceLib.RacePilotChannel obj)
+            : base(obj)
+        {
+            if (obj.Pilot != null)
+                Pilot = obj.Pilot.ID;
+
+            if (obj.Channel != null)
+                Channel = obj.Channel.ID;
+
+            HandicapOffset = obj.HandicapOffset;
+        }
+
+        public override RaceLib.RacePilotChannel GetRaceLibObject(ICollectionDatabase database)
+        {
+            RaceLib.RacePilotChannel pc = base.GetRaceLibObject(database);
+            pc.Pilot = Pilot.Convert<RaceLib.Pilot>(database);
+            pc.Channel = Channel.Convert<RaceLib.Channel>(database);
+            pc.HandicapOffset = HandicapOffset;
+            return pc;
         }
     }
 }

--- a/DB/JSON/Race.cs
+++ b/DB/JSON/Race.cs
@@ -20,6 +20,8 @@ namespace DB.JSON
 
         public TimeSpan TotalPausedTime { get; set; }
 
+        public Dictionary<string, TimeSpan> HandicapOffsets { get; set; }
+
         public List<PilotChannel> PilotChannels { get; set; }
 
         public int RaceNumber { get; set; }
@@ -55,6 +57,8 @@ namespace DB.JSON
                 Event = obj.Event.ID;
             if (obj.GamePoints != null)
                 GamePoints = obj.GamePoints.Convert<GamePoint>().ToList();
+            if (obj.HandicapOffsets != null && obj.HandicapOffsets.Count > 0)
+                HandicapOffsets = obj.HandicapOffsets.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
         }
 
         public override RaceLib.Race GetRaceLibObject(ICollectionDatabase database)
@@ -65,6 +69,16 @@ namespace DB.JSON
             race.PilotChannels = PilotChannels.Convert(database).ToList();
             race.Detections = Detections.Convert(database).ToList();
             race.GamePoints = GamePoints.Convert(database).ToList();
+
+            race.HandicapOffsets = new Dictionary<Guid, TimeSpan>();
+            if (HandicapOffsets != null)
+            {
+                foreach (var kv in HandicapOffsets)
+                {
+                    if (Guid.TryParse(kv.Key, out Guid pilotId))
+                        race.HandicapOffsets[pilotId] = kv.Value;
+                }
+            }
 
             race.Round = Round.Convert<RaceLib.Round>(database);
             race.Event = Event.Convert<RaceLib.Event>(database);

--- a/DB/JSON/Race.cs
+++ b/DB/JSON/Race.cs
@@ -20,9 +20,7 @@ namespace DB.JSON
 
         public TimeSpan TotalPausedTime { get; set; }
 
-        public Dictionary<string, TimeSpan> HandicapOffsets { get; set; }
-
-        public List<PilotChannel> PilotChannels { get; set; }
+        public List<RacePilotChannel> PilotChannels { get; set; }
 
         public int RaceNumber { get; set; }
 
@@ -46,7 +44,7 @@ namespace DB.JSON
             : base(obj)
         {
             if (obj.PilotChannels != null)
-                PilotChannels = obj.PilotChannels.Convert<PilotChannel>().ToList();
+                PilotChannels = obj.PilotChannels.Convert<RacePilotChannel>().ToList();
             if (obj.Laps != null)
                 Laps = obj.Laps.Convert<Lap>().ToList();
             if (obj.Detections != null)
@@ -57,8 +55,6 @@ namespace DB.JSON
                 Event = obj.Event.ID;
             if (obj.GamePoints != null)
                 GamePoints = obj.GamePoints.Convert<GamePoint>().ToList();
-            if (obj.HandicapOffsets != null && obj.HandicapOffsets.Count > 0)
-                HandicapOffsets = obj.HandicapOffsets.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
         }
 
         public override RaceLib.Race GetRaceLibObject(ICollectionDatabase database)
@@ -69,16 +65,6 @@ namespace DB.JSON
             race.PilotChannels = PilotChannels.Convert(database).ToList();
             race.Detections = Detections.Convert(database).ToList();
             race.GamePoints = GamePoints.Convert(database).ToList();
-
-            race.HandicapOffsets = new Dictionary<Guid, TimeSpan>();
-            if (HandicapOffsets != null)
-            {
-                foreach (var kv in HandicapOffsets)
-                {
-                    if (Guid.TryParse(kv.Key, out Guid pilotId))
-                        race.HandicapOffsets[pilotId] = kv.Value;
-                }
-            }
 
             race.Round = Round.Convert<RaceLib.Round>(database);
             race.Event = Event.Convert<RaceLib.Event>(database);

--- a/DB/Round.cs
+++ b/DB/Round.cs
@@ -22,6 +22,8 @@ namespace DB
 
         public DateTime ScheduledStart { get; set; }
 
+        public bool Handicapped { get; set; }
+
         public string GameTypeName { get; set; }
 
         public Guid Stage { get; set; }

--- a/RaceLib/Format/StreetLeague.cs
+++ b/RaceLib/Format/StreetLeague.cs
@@ -83,7 +83,7 @@ namespace RaceLib.Format
                 r.PilotChannels.Clear();
                 foreach (var pc in EventManager.Event.Channels)
                 {
-                    r.PilotChannels.Add(new PilotChannel(null, pc));
+                    r.PilotChannels.Add(new RacePilotChannel(null, pc));
                 }
 
                 List<Pilot> unassignedPilots = new List<Pilot>();

--- a/RaceLib/HandicapCalculator.cs
+++ b/RaceLib/HandicapCalculator.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RaceLib
+{
+    public static class HandicapCalculator
+    {
+        public static Dictionary<Guid, TimeSpan> Calculate(
+            IEnumerable<Pilot> pilots,
+            int raceLaps,
+            int pbLapCount,
+            LapRecordManager lapRecords,
+            TimeSpan? maxOffset = null)
+        {
+            var offsets = new Dictionary<Guid, TimeSpan>();
+
+            if (pilots == null || lapRecords == null) return offsets;
+            if (raceLaps <= 0 || pbLapCount <= 0) return offsets;
+
+            var perLapByPilot = new Dictionary<Pilot, TimeSpan?>();
+            foreach (Pilot p in pilots)
+            {
+                if (p == null) continue;
+
+                if (lapRecords.GetBestLaps(p, pbLapCount, out Lap[] best, out _)
+                    && best != null && best.Length == pbLapCount)
+                {
+                    TimeSpan total = best.TotalTime();
+                    perLapByPilot[p] = TimeSpan.FromTicks(total.Ticks / pbLapCount);
+                }
+                else
+                {
+                    perLapByPilot[p] = null;
+                }
+            }
+
+            var withPB = perLapByPilot.Where(kv => kv.Value.HasValue).ToList();
+            if (withPB.Count < 2) return offsets;
+
+            TimeSpan slowestPerLap = withPB.Max(kv => kv.Value.Value);
+
+            foreach (var kv in perLapByPilot)
+            {
+                if (!kv.Value.HasValue) continue;
+
+                TimeSpan delta = slowestPerLap - kv.Value.Value;
+                if (delta <= TimeSpan.Zero) continue;
+
+                TimeSpan offset = TimeSpan.FromTicks(delta.Ticks * raceLaps);
+                if (maxOffset.HasValue && offset > maxOffset.Value)
+                    offset = maxOffset.Value;
+
+                offsets[kv.Key.ID] = offset;
+            }
+
+            return offsets;
+        }
+    }
+}

--- a/RaceLib/HandicapCalculator.cs
+++ b/RaceLib/HandicapCalculator.cs
@@ -6,19 +6,19 @@ namespace RaceLib
 {
     public static class HandicapCalculator
     {
-        public static Dictionary<Guid, TimeSpan> Calculate(
+        public static Dictionary<Pilot, TimeSpan> Calculate(
             IEnumerable<Pilot> pilots,
             int raceLaps,
             int pbLapCount,
             LapRecordManager lapRecords,
             TimeSpan? maxOffset = null)
         {
-            var offsets = new Dictionary<Guid, TimeSpan>();
+            Dictionary<Pilot, TimeSpan> offsets = new Dictionary<Pilot, TimeSpan>();
 
             if (pilots == null || lapRecords == null) return offsets;
             if (raceLaps <= 0 || pbLapCount <= 0) return offsets;
 
-            var perLapByPilot = new Dictionary<Pilot, TimeSpan?>();
+            Dictionary<Pilot, TimeSpan?> perLapByPilot = new Dictionary<Pilot, TimeSpan?>();
             foreach (Pilot p in pilots)
             {
                 if (p == null) continue;
@@ -35,12 +35,12 @@ namespace RaceLib
                 }
             }
 
-            var withPB = perLapByPilot.Where(kv => kv.Value.HasValue).ToList();
+            List<KeyValuePair<Pilot, TimeSpan?>> withPB = perLapByPilot.Where(kv => kv.Value.HasValue).ToList();
             if (withPB.Count < 2) return offsets;
 
             TimeSpan slowestPerLap = withPB.Max(kv => kv.Value.Value);
 
-            foreach (var kv in perLapByPilot)
+            foreach (KeyValuePair<Pilot, TimeSpan?> kv in perLapByPilot)
             {
                 if (!kv.Value.HasValue) continue;
 
@@ -51,7 +51,7 @@ namespace RaceLib
                 if (maxOffset.HasValue && offset > maxOffset.Value)
                     offset = maxOffset.Value;
 
-                offsets[kv.Key.ID] = offset;
+                offsets[kv.Key] = offset;
             }
 
             return offsets;

--- a/RaceLib/PilotChannel.cs
+++ b/RaceLib/PilotChannel.cs
@@ -43,16 +43,40 @@ namespace RaceLib
             return Pilot.ToString() + " " + Channel.ToString();
         }
 
-        public PilotChannel Clone()
+        public virtual PilotChannel Clone()
         {
             // This is important, pilot channels cannot be shared between races, events, etc
             return new PilotChannel(Pilot, Channel);
         }
     }
 
+    public class RacePilotChannel : PilotChannel
+    {
+        public TimeSpan HandicapOffset { get; set; }
+
+        public RacePilotChannel()
+        {
+        }
+
+        public RacePilotChannel(Pilot p, Channel c)
+            : base(p, c)
+        {
+        }
+
+        public override RacePilotChannel Clone()
+        {
+            return new RacePilotChannel(Pilot, Channel) { HandicapOffset = HandicapOffset };
+        }
+    }
+
     public static class PilotChannelExtensions
     {
         public static IEnumerable<PilotChannel> Clone(this IEnumerable<PilotChannel> pilotChannels)
+        {
+            return pilotChannels.Select(pc => pc.Clone());
+        }
+
+        public static IEnumerable<RacePilotChannel> Clone(this IEnumerable<RacePilotChannel> pilotChannels)
         {
             return pilotChannels.Select(pc => pc.Clone());
         }
@@ -72,7 +96,17 @@ namespace RaceLib
             return pilotChannels.FirstOrDefault(pc => pc != null && pc.Channel != null && pc.Channel.InterferesWith(channel));
         }
 
+        public static RacePilotChannel Get(this IEnumerable<RacePilotChannel> pilotChannels, Channel channel)
+        {
+            return pilotChannels.FirstOrDefault(pc => pc != null && pc.Channel != null && pc.Channel.InterferesWith(channel));
+        }
+
         public static PilotChannel Get(this IEnumerable<PilotChannel> pilotChannels, Pilot pilot)
+        {
+            return pilotChannels.FirstOrDefault(pc => pc.Pilot == pilot);
+        }
+
+        public static RacePilotChannel Get(this IEnumerable<RacePilotChannel> pilotChannels, Pilot pilot)
         {
             return pilotChannels.FirstOrDefault(pc => pc.Pilot == pilot);
         }

--- a/RaceLib/Race.cs
+++ b/RaceLib/Race.cs
@@ -41,14 +41,11 @@ namespace RaceLib
         public TimeSpan TotalPausedTime { get; set; }
 
         [System.ComponentModel.Browsable(false)]
-        public Dictionary<Guid, TimeSpan> HandicapOffsets { get; set; }
-
-        [System.ComponentModel.Browsable(false)]
-        public List<PilotChannel> PilotChannels { get; set; }
+        public List<RacePilotChannel> PilotChannels { get; set; }
        
         [System.ComponentModel.Browsable(false)]
         
-        public PilotChannel[] PilotChannelsSafe 
+        public RacePilotChannel[] PilotChannelsSafe 
         { 
             get 
             {
@@ -277,10 +274,9 @@ namespace RaceLib
             Valid = true;
             PrimaryTimingSystemLocation = PrimaryTimingSystemLocation.EndOfLap;
             Laps = new List<Lap>();
-            PilotChannels = new List<PilotChannel>();
+            PilotChannels = new List<RacePilotChannel>();
             Detections = new List<Detection>();
             GamePoints = new List<GamePoint>();
-            HandicapOffsets = new Dictionary<Guid, TimeSpan>();
             AutoAssignNumbers = false;
             TargetLaps = 0;
         }
@@ -318,7 +314,7 @@ namespace RaceLib
         }
 
 
-        public PilotChannel GetPilotChannel(Channel c)
+        public RacePilotChannel GetPilotChannel(Channel c)
         {
             lock (PilotChannels)
             {
@@ -326,7 +322,7 @@ namespace RaceLib
             }
         }
 
-        public PilotChannel GetPilotChannel(Pilot p)
+        public RacePilotChannel GetPilotChannel(Pilot p)
         {
             lock (PilotChannels)
             {
@@ -339,7 +335,7 @@ namespace RaceLib
             return Laps.Any(l => l.Pilot == p && l.Detection.Valid);
         }
 
-        public PilotChannel SetPilot(IDatabase db, Channel channel, Pilot p, bool force = false)
+        public RacePilotChannel SetPilot(IDatabase db, Channel channel, Pilot p, bool force = false)
         {
             if (channel == null || p == null)
                 return null;
@@ -353,7 +349,7 @@ namespace RaceLib
             if (!IsFrequencyFree(channel))
                 return null;
 
-            PilotChannel pc = new PilotChannel(p, channel);
+            RacePilotChannel pc = new RacePilotChannel(p, channel);
             lock (PilotChannels)
             {
                 PilotChannels.Add(pc);
@@ -366,11 +362,11 @@ namespace RaceLib
             return pc;
         }
 
-        public PilotChannel ClearChannel(IDatabase db, Channel channel)
+        public RacePilotChannel ClearChannel(IDatabase db, Channel channel)
         {
             lock (PilotChannels)
             {
-                PilotChannel pc = PilotChannels.Get(channel);
+                RacePilotChannel pc = PilotChannels.Get(channel);
                 if (pc != null)
                 {
                     PilotChannels.Remove(pc);
@@ -381,7 +377,7 @@ namespace RaceLib
             return null;
         }
 
-        public PilotChannel RemovePilot(IDatabase db, Pilot pilot, bool force = false)
+        public RacePilotChannel RemovePilot(IDatabase db, Pilot pilot, bool force = false)
         {
             if (!force && Ended)
             {
@@ -390,7 +386,7 @@ namespace RaceLib
 
             lock (PilotChannels)
             {
-                PilotChannel pc = GetPilotChannel(pilot);
+                RacePilotChannel pc = GetPilotChannel(pilot);
                 if (pc != null)
                 {
                     PilotChannels.Remove(pc);
@@ -404,7 +400,7 @@ namespace RaceLib
 
         public Channel GetChannel(Pilot pilot)
         {
-            PilotChannel pc = GetPilotChannel(pilot);
+            RacePilotChannel pc = GetPilotChannel(pilot);
             if (pc != null)
             {
                 return pc.Channel;
@@ -417,7 +413,7 @@ namespace RaceLib
         {
             lock (PilotChannels)
             {
-                PilotChannel pc = PilotChannels.FirstOrDefault(pac => pac.Channel != null && channels.Contains(pac.Channel));
+                RacePilotChannel pc = PilotChannels.FirstOrDefault(pac => pac.Channel != null && channels.Contains(pac.Channel));
                 if (pc != null)
                 {
                     return pc.Pilot;
@@ -430,7 +426,7 @@ namespace RaceLib
         {
             lock (PilotChannels)
             {
-                PilotChannel pc = PilotChannels.FirstOrDefault(pac => pac.Channel != null && pac.Channel == channel);
+                RacePilotChannel pc = PilotChannels.FirstOrDefault(pac => pac.Channel != null && pac.Channel == channel);
                 if (pc != null)
                 {
                     return pc.Pilot;
@@ -439,11 +435,11 @@ namespace RaceLib
             return null;
         }
 
-        public PilotChannel GetPilotChannel(int freq)
+        public RacePilotChannel GetPilotChannel(int freq)
         {
             lock (PilotChannels)
             {
-                PilotChannel pc = PilotChannels.FirstOrDefault(pac => pac.Channel != null && pac.Channel.Frequency == freq);
+                RacePilotChannel pc = PilotChannels.FirstOrDefault(pac => pac.Channel != null && pac.Channel.Frequency == freq);
                 if (pc != null)
                 {
                     return pc;
@@ -454,7 +450,7 @@ namespace RaceLib
 
         public Pilot GetPilot(int freq)
         {
-            PilotChannel pc = GetPilotChannel(freq);
+            RacePilotChannel pc = GetPilotChannel(freq);
             if (pc != null)
             {
                 return pc.Pilot;
@@ -710,9 +706,11 @@ namespace RaceLib
 
         public DateTime GetHandicappedStart(Pilot p)
         {
-            if (p != null && HandicapOffsets != null && HandicapOffsets.TryGetValue(p.ID, out TimeSpan offset))
+            if (p != null)
             {
-                return Start + offset;
+                RacePilotChannel pc = GetPilotChannel(p);
+                if (pc != null && pc.HandicapOffset > TimeSpan.Zero)
+                    return Start + pc.HandicapOffset;
             }
             return Start;
         }
@@ -804,9 +802,9 @@ namespace RaceLib
 
         public bool SwapPilots(IDatabase db, Pilot newPilot, Channel newChannel, Race oldRace)
         {
-            PilotChannel existingPilotChannel = GetPilotChannel(newChannel.Frequency);
+            RacePilotChannel existingPilotChannel = GetPilotChannel(newChannel.Frequency);
             Pilot existingPilot = null;
-            PilotChannel oldPilotChannel = oldRace.GetPilotChannel(newPilot);
+            RacePilotChannel oldPilotChannel = oldRace.GetPilotChannel(newPilot);
             Channel oldChannel = Channel.None;
 
             if (existingPilotChannel != null)

--- a/RaceLib/Race.cs
+++ b/RaceLib/Race.cs
@@ -41,6 +41,9 @@ namespace RaceLib
         public TimeSpan TotalPausedTime { get; set; }
 
         [System.ComponentModel.Browsable(false)]
+        public Dictionary<Guid, TimeSpan> HandicapOffsets { get; set; }
+
+        [System.ComponentModel.Browsable(false)]
         public List<PilotChannel> PilotChannels { get; set; }
        
         [System.ComponentModel.Browsable(false)]
@@ -277,6 +280,7 @@ namespace RaceLib
             PilotChannels = new List<PilotChannel>();
             Detections = new List<Detection>();
             GamePoints = new List<GamePoint>();
+            HandicapOffsets = new Dictionary<Guid, TimeSpan>();
             AutoAssignNumbers = false;
             TargetLaps = 0;
         }
@@ -704,18 +708,29 @@ namespace RaceLib
             db.Update(this);
         }
 
+        public DateTime GetHandicappedStart(Pilot p)
+        {
+            if (p != null && HandicapOffsets != null && HandicapOffsets.TryGetValue(p.ID, out TimeSpan offset))
+            {
+                return Start + offset;
+            }
+            return Start;
+        }
+
         public DateTime GetRaceStartTime(Pilot p)
         {
+            DateTime baseStart = GetHandicappedStart(p);
+
             if (PrimaryTimingSystemLocation == PrimaryTimingSystemLocation.Holeshot)
             {
                 Lap lap = GetHoleshot(p);
-                if (lap != null)
+                if (lap != null && lap.End >= baseStart)
                 {
                     return lap.End;
                 }
             }
 
-            return Start;
+            return baseStart;
         }
         public void ReCalculateLaps(IDatabase db, Pilot pilot)
         {

--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -42,6 +42,7 @@ namespace RaceLib
         public event Action<Race, bool> OnRaceCancelled;
         public event Action<Race, TimeSpan> OnRaceTimeRemaining;
         public event Action<Race> OnRaceTimesUp;
+        public event Action<Race, Pilot> OnPilotHandicapStart;
 
         public event Race.OnRaceEvent OnRaceRemoved;
 
@@ -789,6 +790,38 @@ namespace RaceLib
             }
 
             OnRaceStart?.Invoke(currentRace);
+
+            ScheduleHandicapStartCues(currentRace, startTime);
+        }
+
+        private void ScheduleHandicapStartCues(Race race, DateTime raceStart)
+        {
+            if (race == null || race.HandicapOffsets == null || race.HandicapOffsets.Count == 0)
+                return;
+
+            foreach (PilotChannel pc in race.PilotChannelsSafe)
+            {
+                if (pc.Pilot == null)
+                    continue;
+
+                TimeSpan offset;
+                if (!race.HandicapOffsets.TryGetValue(pc.Pilot.ID, out offset))
+                    offset = TimeSpan.Zero;
+
+                DateTime fireAt = raceStart + offset;
+                TimeSpan delay = fireAt - DateTime.Now;
+                if (delay < TimeSpan.Zero)
+                    delay = TimeSpan.Zero;
+
+                Pilot capturedPilot = pc.Pilot;
+                Race capturedRace = race;
+                Task.Delay(delay).ContinueWith(t =>
+                {
+                    if (CurrentRace != capturedRace || !capturedRace.Running)
+                        return;
+                    OnPilotHandicapStart?.Invoke(capturedRace, capturedPilot);
+                }, TaskScheduler.Default);
+            }
         }
 
         private void CheckEventStart(IDatabase db)
@@ -1215,11 +1248,20 @@ namespace RaceLib
             if (race == null || race.Round == null) return;
             if (!race.Round.Handicapped) return;
             if (race.Ended || race.Started) return;
-            if (!race.Type.HasLaps()) return;
             if (race.HandicapOffsets != null && race.HandicapOffsets.Count > 0) return;
 
+            if (!race.Type.HasLaps())
+            {
+                Logger.RaceLog.LogCall(this, race, "Handicap requested but race type has no laps; skipping");
+                return;
+            }
+
             int targetLaps = race.TargetLaps > 0 ? race.TargetLaps : EventManager.Event.Laps;
-            if (targetLaps <= 0) return;
+            if (targetLaps <= 0)
+            {
+                Logger.RaceLog.LogCall(this, race, "Handicap requested but no lap target (TimesUp race); skipping");
+                return;
+            }
 
             int pbLaps = EventManager.Event.PBLaps;
             if (pbLaps <= 0) return;

--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -796,19 +796,15 @@ namespace RaceLib
 
         private void ScheduleHandicapStartCues(Race race, DateTime raceStart)
         {
-            if (race == null || race.HandicapOffsets == null || race.HandicapOffsets.Count == 0)
+            if (race == null || race.Round == null || !race.Round.Handicapped)
                 return;
 
-            foreach (PilotChannel pc in race.PilotChannelsSafe)
+            foreach (RacePilotChannel pc in race.PilotChannelsSafe)
             {
                 if (pc.Pilot == null)
                     continue;
 
-                TimeSpan offset;
-                if (!race.HandicapOffsets.TryGetValue(pc.Pilot.ID, out offset))
-                    offset = TimeSpan.Zero;
-
-                DateTime fireAt = raceStart + offset;
+                DateTime fireAt = raceStart + pc.HandicapOffset;
                 TimeSpan delay = fireAt - DateTime.Now;
                 if (delay < TimeSpan.Zero)
                     delay = TimeSpan.Zero;
@@ -1265,11 +1261,18 @@ namespace RaceLib
             int pbLaps = EventManager.Event.PBLaps;
             if (pbLaps <= 0) return;
 
-            race.HandicapOffsets = HandicapCalculator.Calculate(
+            Dictionary<Pilot, TimeSpan> offsets = HandicapCalculator.Calculate(
                 race.Pilots,
                 targetLaps,
                 pbLaps,
                 EventManager.LapRecordManager);
+
+            foreach (RacePilotChannel pc in race.PilotChannelsSafe)
+            {
+                if (pc.Pilot == null) continue;
+                TimeSpan offset;
+                pc.HandicapOffset = offsets.TryGetValue(pc.Pilot, out offset) ? offset : TimeSpan.Zero;
+            }
         }
 
         public void SetupCasualPractice(Race race)

--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -1183,6 +1183,9 @@ namespace RaceLib
 
                 //Update the first detection so it matches the event so you can change it on an existing race and rerun it.
                 currentRace.PrimaryTimingSystemLocation = EventManager.Event.PrimaryTimingSystemLocation;
+
+                ComputeHandicapOffsets(currentRace);
+
                 OnRaceChanged?.Invoke(currentRace);
 
                 if (currentRace != null)
@@ -1205,6 +1208,27 @@ namespace RaceLib
                 return true;
             }
             return false;
+        }
+
+        private void ComputeHandicapOffsets(Race race)
+        {
+            if (race == null || race.Round == null) return;
+            if (!race.Round.Handicapped) return;
+            if (race.Ended || race.Started) return;
+            if (!race.Type.HasLaps()) return;
+            if (race.HandicapOffsets != null && race.HandicapOffsets.Count > 0) return;
+
+            int targetLaps = race.TargetLaps > 0 ? race.TargetLaps : EventManager.Event.Laps;
+            if (targetLaps <= 0) return;
+
+            int pbLaps = EventManager.Event.PBLaps;
+            if (pbLaps <= 0) return;
+
+            race.HandicapOffsets = HandicapCalculator.Calculate(
+                race.Pilots,
+                targetLaps,
+                pbLaps,
+                EventManager.LapRecordManager);
         }
 
         public void SetupCasualPractice(Race race)
@@ -1409,13 +1433,15 @@ namespace RaceLib
             if (detection.TimingSystemType != TimingSystemType.Manual || EventType != EventTypes.Training)
             {
                 // We start the timer before the race start, so just ignore any times in there...
-                if (currentRace.Start > detection.Time)
+                // For handicapped pilots, gate against their personal staggered start instead of Race.Start.
+                DateTime pilotStart = currentRace.GetHandicappedStart(detection.Pilot);
+                if (pilotStart > detection.Time)
                 {
                     detection.Valid = false;
                 }
 
                 //Inside race start ignore window. Which is disabled in the UI for holeshot..
-                if (currentRace.Start + eve.RaceStartIgnoreDetections > detection.Time)
+                if (pilotStart + eve.RaceStartIgnoreDetections > detection.Time)
                 {
                     detection.Valid = false;
                 }

--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -1243,12 +1243,11 @@ namespace RaceLib
             return false;
         }
 
-        private void ComputeHandicapOffsets(Race race)
+        public void ComputeHandicapOffsets(Race race)
         {
             if (race == null || race.Round == null) return;
             if (!race.Round.Handicapped) return;
             if (race.Ended || race.Started) return;
-            if (race.HandicapOffsets != null && race.HandicapOffsets.Count > 0) return;
 
             if (!race.Type.HasLaps())
             {

--- a/RaceLib/ResultManager.cs
+++ b/RaceLib/ResultManager.cs
@@ -557,7 +557,7 @@ namespace RaceLib
                     }
                     else
                     {
-                        r.Time = lastDetection.Time - race.Start;
+                        r.Time = lastDetection.Time - race.GetRaceStartTime(pilot);
                     }
                     r.LapsFinished = lastDetection.LapNumber;
                 }

--- a/RaceLib/Round.cs
+++ b/RaceLib/Round.cs
@@ -26,6 +26,9 @@ namespace RaceLib
         [Category("Editable Details")]
         public DateTime ScheduledStart { get; set; }
 
+        [Category("Editable Details")]
+        public bool Handicapped { get; set; }
+
 
         [Category("Advanced")]
         public int Order { get; set; }

--- a/Sound/SoundManager.cs
+++ b/Sound/SoundManager.cs
@@ -134,6 +134,7 @@ namespace Sound
             {
                 em.RaceManager.OnRaceStart += RaceManager_OnRaceStart;
                 em.RaceManager.OnRaceStartScheduled += RaceManager_OnRaceStartScheduled;
+                em.RaceManager.OnPilotHandicapStart += RaceManager_OnPilotHandicapStart;
                 em.RaceManager.OnRaceEnd += RaceOver;
                 em.RaceManager.OnLapDetected += Lap;
                 em.RaceManager.OnSplitDetection += Sector;
@@ -170,6 +171,7 @@ namespace Sound
             {
                 em.RaceManager.OnRaceStart -= RaceManager_OnRaceStart;
                 em.RaceManager.OnRaceStartScheduled -= RaceManager_OnRaceStartScheduled;
+                em.RaceManager.OnPilotHandicapStart -= RaceManager_OnPilotHandicapStart;
                 em.RaceManager.OnRaceEnd -= RaceOver;
                 em.RaceManager.OnLapDetected -= Lap;
                 em.RaceManager.OnSplitDetection -= Sector;
@@ -419,10 +421,27 @@ namespace Sound
 
         private void RaceManager_OnRaceStart(Race race)
         {
-            if (!eventManager.RaceManager.StaggeredStart)
-            {
-                Start();
-            }
+            if (eventManager.RaceManager.StaggeredStart)
+                return;
+
+            // Suppress the global "GO" for handicap races — per-pilot cues fire individually.
+            if (race != null && race.HandicapOffsets != null && race.HandicapOffsets.Count > 0)
+                return;
+
+            Start();
+        }
+
+        private void RaceManager_OnPilotHandicapStart(Race race, Pilot pilot)
+        {
+            if (pilot == null)
+                return;
+
+            SpeechParameters sp = new SpeechParameters();
+            sp.Add(SpeechParameters.Types.pilot, pilot);
+            sp.Priority = 9500;
+            sp.SecondsExpiry = 2;
+
+            PlaySound(SoundKey.StaggeredPilot, sp);
         }
 
         private void RaceManager_OnRaceStartScheduled(Race race, DateTime startTime)

--- a/Sound/SoundManager.cs
+++ b/Sound/SoundManager.cs
@@ -425,7 +425,7 @@ namespace Sound
                 return;
 
             // Suppress the global "GO" for handicap races — per-pilot cues fire individually.
-            if (race != null && race.HandicapOffsets != null && race.HandicapOffsets.Count > 0)
+            if (race != null && race.Round != null && race.Round.Handicapped)
                 return;
 
             Start();

--- a/UI/Nodes/ChannelNodeBase.cs
+++ b/UI/Nodes/ChannelNodeBase.cs
@@ -108,6 +108,11 @@ namespace UI.Nodes
         private bool needsLapRefresh;
         private bool needsSplitClear;
 
+        private ColorNode goFlashBackground;
+        private TextNode goFlashText;
+        private DateTime? goFlashEnd;
+        private static readonly TimeSpan GoFlashDuration = TimeSpan.FromSeconds(1.5);
+
         public event Action RequestReorder;
         public event Action OnPBChange;
 
@@ -163,6 +168,7 @@ namespace UI.Nodes
             EventManager.LapRecordManager.OnNewPersonalBest += RecordManager_OnNewPersonalBest;
             EventManager.RaceManager.OnRaceResumed += RaceManager_OnRaceStateChanged;
             EventManager.GameManager.OnGamePointChanged += RaceManager_OnGamePoint;
+            EventManager.RaceManager.OnPilotHandicapStart += RaceManager_OnPilotHandicapStart;
         }
 
 
@@ -182,6 +188,7 @@ namespace UI.Nodes
             EventManager.RaceManager.OnLapsRecalculated -= RaceManager_OnLapsRecalculated;
             EventManager.LapRecordManager.OnNewPersonalBest -= RecordManager_OnNewPersonalBest;
             EventManager.GameManager.OnGamePointChanged -= RaceManager_OnGamePoint;
+            EventManager.RaceManager.OnPilotHandicapStart -= RaceManager_OnPilotHandicapStart;
 
             base.Dispose();
         }
@@ -219,6 +226,13 @@ namespace UI.Nodes
         {
             CrashedOutType = CrashState.AutoUp;
             needUpdatePosition = true;
+        }
+
+        private void RaceManager_OnPilotHandicapStart(Race race, Pilot pilot)
+        {
+            if (pilot == null || Pilot == null) return;
+            if (pilot.ID != Pilot.ID) return;
+            goFlashEnd = DateTime.Now + GoFlashDuration;
         }
 
         private void RaceManager_OnLapDisqualified(Lap lap)
@@ -444,6 +458,21 @@ namespace UI.Nodes
             crashedOut.KeepAspectRatio = false;
             crashedOut.Visible = false;
             DisplayNode.AddChild(crashedOut);
+
+            goFlashBackground = new ColorNode(new Color(40, 220, 80));
+            goFlashBackground.KeepAspectRatio = false;
+            goFlashBackground.Visible = false;
+            goFlashBackground.Alpha = 0;
+            DisplayNode.AddChild(goFlashBackground);
+
+            goFlashText = new TextNode("GO!", Color.White);
+            goFlashText.Style.Bold = true;
+            goFlashText.Style.Border = true;
+            goFlashText.Alignment = RectangleAlignment.Center;
+            goFlashText.RelativeBounds = new RectangleF(0.1f, 0.2f, 0.8f, 0.6f);
+            goFlashText.Visible = false;
+            goFlashText.Alpha = 0;
+            DisplayNode.AddChild(goFlashText);
 
             DisplayNode.AddChild(velocidroneGateContainer);
 
@@ -893,7 +922,42 @@ namespace UI.Nodes
             // udpdate crashed out visible
             crashedOut.Visible = CrashedOut && !resultContainer.Visible;
 
+            UpdateGoFlash();
+
             base.Update(gameTime);
+        }
+
+        private void UpdateGoFlash()
+        {
+            if (goFlashBackground == null || goFlashText == null) return;
+
+            if (!goFlashEnd.HasValue)
+            {
+                if (goFlashBackground.Visible)
+                {
+                    goFlashBackground.Visible = false;
+                    goFlashText.Visible = false;
+                }
+                return;
+            }
+
+            TimeSpan remaining = goFlashEnd.Value - DateTime.Now;
+            if (remaining <= TimeSpan.Zero)
+            {
+                goFlashEnd = null;
+                goFlashBackground.Visible = false;
+                goFlashText.Visible = false;
+                return;
+            }
+
+            float t = (float)(remaining.TotalSeconds / GoFlashDuration.TotalSeconds);
+            if (t < 0f) t = 0f;
+            if (t > 1f) t = 1f;
+
+            goFlashBackground.Visible = true;
+            goFlashText.Visible = true;
+            goFlashBackground.Alpha = 0.55f * t;
+            goFlashText.Alpha = t;
         }
 
 

--- a/UI/Nodes/HandicapStartBarNode.cs
+++ b/UI/Nodes/HandicapStartBarNode.cs
@@ -1,0 +1,228 @@
+using Composition;
+using Composition.Nodes;
+using Microsoft.Xna.Framework;
+using RaceLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tools;
+
+namespace UI.Nodes
+{
+    public class HandicapStartBarNode : ColorNode, IUpdateableNode
+    {
+        private readonly EventManager eventManager;
+
+        private readonly TextNode label;
+        private readonly ColorNode track;
+        private readonly ColorNode cursor;
+        private readonly TextNode cursorLabel;
+        private readonly Node chipContainer;
+
+        private Race trackedRace;
+        private TimeSpan windowDuration;
+        private DateTime hideAt;
+        private bool active;
+
+        private const float TrailingGraceSeconds = 2.0f;
+
+        public HandicapStartBarNode(EventManager eventManager)
+            : base(new Color(0, 0, 0, 170))
+        {
+            this.eventManager = eventManager;
+
+            label = new TextNode("Handicap start", Color.White);
+            label.Alignment = RectangleAlignment.CenterLeft;
+            label.RelativeBounds = new RectangleF(0.005f, 0.0f, 0.18f, 1.0f);
+            label.Style.Border = true;
+            AddChild(label);
+
+            track = new ColorNode(new Color(255, 255, 255, 60));
+            track.KeepAspectRatio = false;
+            track.RelativeBounds = new RectangleF(0.2f, 0.45f, 0.78f, 0.1f);
+            AddChild(track);
+
+            chipContainer = new Node();
+            chipContainer.RelativeBounds = new RectangleF(0.2f, 0.0f, 0.78f, 1.0f);
+            AddChild(chipContainer);
+
+            cursor = new ColorNode(new Color(255, 220, 60));
+            cursor.KeepAspectRatio = false;
+            cursor.RelativeBounds = new RectangleF(0.2f, 0.05f, 0.003f, 0.9f);
+            cursor.Visible = false;
+            AddChild(cursor);
+
+            cursorLabel = new TextNode("", new Color(255, 220, 60));
+            cursorLabel.Alignment = RectangleAlignment.CenterLeft;
+            cursorLabel.Style.Border = true;
+            cursorLabel.Visible = false;
+            AddChild(cursorLabel);
+
+            Visible = false;
+
+            eventManager.RaceManager.OnRaceChanged += OnRaceChanged;
+            eventManager.RaceManager.OnRacePreStart += OnRacePreStart;
+            eventManager.RaceManager.OnRaceStart += OnRaceStart;
+            eventManager.RaceManager.OnRaceEnd += OnRaceEnded;
+            eventManager.RaceManager.OnRaceClear += OnRaceCleared;
+            eventManager.RaceManager.OnRaceReset += OnRaceCleared;
+        }
+
+        public override void Dispose()
+        {
+            eventManager.RaceManager.OnRaceChanged -= OnRaceChanged;
+            eventManager.RaceManager.OnRacePreStart -= OnRacePreStart;
+            eventManager.RaceManager.OnRaceStart -= OnRaceStart;
+            eventManager.RaceManager.OnRaceEnd -= OnRaceEnded;
+            eventManager.RaceManager.OnRaceClear -= OnRaceCleared;
+            eventManager.RaceManager.OnRaceReset -= OnRaceCleared;
+            base.Dispose();
+        }
+
+        private void OnRaceChanged(Race race)
+        {
+            Rebuild(race);
+        }
+
+        private void OnRacePreStart(Race race)
+        {
+            Rebuild(race);
+        }
+
+        private void OnRaceStart(Race race)
+        {
+            if (race == null || trackedRace != race) Rebuild(race);
+            if (!active) return;
+            hideAt = race.Start + windowDuration + TimeSpan.FromSeconds(TrailingGraceSeconds);
+            cursor.Visible = true;
+            cursorLabel.Visible = true;
+        }
+
+        private void OnRaceEnded(Race race)
+        {
+            Hide();
+        }
+
+        private void OnRaceCleared(Race race)
+        {
+            Hide();
+        }
+
+        private void Hide()
+        {
+            active = false;
+            trackedRace = null;
+            Visible = false;
+            cursor.Visible = false;
+            cursorLabel.Visible = false;
+        }
+
+        private void Rebuild(Race race)
+        {
+            chipContainer.ClearDisposeChildren();
+
+            if (race == null || race.Round == null || !race.Round.Handicapped
+                || race.HandicapOffsets == null || race.HandicapOffsets.Count == 0
+                || race.Ended)
+            {
+                Hide();
+                return;
+            }
+
+            trackedRace = race;
+            active = true;
+
+            TimeSpan maxOffset = TimeSpan.Zero;
+            foreach (var kv in race.HandicapOffsets)
+            {
+                if (kv.Value > maxOffset) maxOffset = kv.Value;
+            }
+            if (maxOffset < TimeSpan.FromSeconds(0.5)) maxOffset = TimeSpan.FromSeconds(0.5);
+            windowDuration = maxOffset;
+
+            label.Text = "Handicap start (" + maxOffset.TotalSeconds.ToString("0.0") + "s)";
+
+            foreach (PilotChannel pc in race.PilotChannelsSafe)
+            {
+                if (pc.Pilot == null || pc.Channel == null) continue;
+
+                TimeSpan offset;
+                if (!race.HandicapOffsets.TryGetValue(pc.Pilot.ID, out offset))
+                    offset = TimeSpan.Zero;
+
+                float t = (float)(offset.TotalSeconds / maxOffset.TotalSeconds);
+                if (t < 0f) t = 0f;
+                if (t > 1f) t = 1f;
+
+                Color channelColor = eventManager.GetRaceChannelColor(race, pc.Channel);
+
+                ColorNode chip = new ColorNode(channelColor);
+                chip.KeepAspectRatio = false;
+                float chipWidth = 0.04f;
+                float chipX = t * (1.0f - chipWidth);
+                chip.RelativeBounds = new RectangleF(chipX, 0.15f, chipWidth, 0.55f);
+                chipContainer.AddChild(chip);
+
+                TextNode chipLabel = new TextNode(pc.Pilot.Name + "  +" + offset.TotalSeconds.ToString("0.0") + "s", Color.White);
+                chipLabel.Alignment = RectangleAlignment.TopLeft;
+                chipLabel.Style.Border = true;
+                chipLabel.RelativeBounds = new RectangleF(chipX, 0.72f, 0.25f, 0.28f);
+                chipContainer.AddChild(chipLabel);
+            }
+
+            Visible = true;
+
+            if (race.Started && !race.Ended)
+            {
+                hideAt = race.Start + windowDuration + TimeSpan.FromSeconds(TrailingGraceSeconds);
+                cursor.Visible = true;
+                cursorLabel.Visible = true;
+            }
+            else
+            {
+                cursor.Visible = false;
+                cursorLabel.Visible = false;
+            }
+        }
+
+        public void Update(GameTime gameTime)
+        {
+            if (!active || trackedRace == null) return;
+
+            if (!trackedRace.Started)
+            {
+                cursor.Visible = false;
+                cursorLabel.Visible = false;
+                return;
+            }
+
+            if (DateTime.Now >= hideAt)
+            {
+                Hide();
+                return;
+            }
+
+            TimeSpan elapsed = DateTime.Now - trackedRace.Start;
+            double secs = elapsed.TotalSeconds;
+            double total = windowDuration.TotalSeconds;
+            if (total <= 0) return;
+
+            float t = (float)(secs / total);
+            if (t < 0f) t = 0f;
+            if (t > 1f) t = 1f;
+
+            float trackLeft = 0.2f;
+            float trackWidth = 0.78f;
+            float xRel = trackLeft + t * trackWidth;
+            cursor.RelativeBounds = new RectangleF(xRel - 0.0015f, 0.05f, 0.003f, 0.9f);
+
+            cursorLabel.Text = secs.ToString("0.0") + "s";
+            float labelWidth = 0.06f;
+            float labelX = xRel + 0.005f;
+            if (labelX + labelWidth > 1f) labelX = xRel - labelWidth - 0.005f;
+            cursorLabel.RelativeBounds = new RectangleF(labelX, 0.05f, labelWidth, 0.4f);
+
+            RequestLayout();
+        }
+    }
+}

--- a/UI/Nodes/HandicapStartBarNode.cs
+++ b/UI/Nodes/HandicapStartBarNode.cs
@@ -121,9 +121,19 @@ namespace UI.Nodes
         {
             chipContainer.ClearDisposeChildren();
 
-            if (race == null || race.Round == null || !race.Round.Handicapped
-                || race.HandicapOffsets == null || race.HandicapOffsets.Count == 0
-                || race.Ended)
+            if (race == null || race.Round == null || !race.Round.Handicapped || race.Ended)
+            {
+                Hide();
+                return;
+            }
+
+            TimeSpan maxOffset = TimeSpan.Zero;
+            foreach (RacePilotChannel pc in race.PilotChannelsSafe)
+            {
+                if (pc.HandicapOffset > maxOffset) maxOffset = pc.HandicapOffset;
+            }
+
+            if (maxOffset <= TimeSpan.Zero)
             {
                 Hide();
                 return;
@@ -132,23 +142,16 @@ namespace UI.Nodes
             trackedRace = race;
             active = true;
 
-            TimeSpan maxOffset = TimeSpan.Zero;
-            foreach (var kv in race.HandicapOffsets)
-            {
-                if (kv.Value > maxOffset) maxOffset = kv.Value;
-            }
             if (maxOffset < TimeSpan.FromSeconds(0.5)) maxOffset = TimeSpan.FromSeconds(0.5);
             windowDuration = maxOffset;
 
             label.Text = "Handicap start (" + maxOffset.TotalSeconds.ToString("0.0") + "s)";
 
-            foreach (PilotChannel pc in race.PilotChannelsSafe)
+            foreach (RacePilotChannel pc in race.PilotChannelsSafe)
             {
                 if (pc.Pilot == null || pc.Channel == null) continue;
 
-                TimeSpan offset;
-                if (!race.HandicapOffsets.TryGetValue(pc.Pilot.ID, out offset))
-                    offset = TimeSpan.Zero;
+                TimeSpan offset = pc.HandicapOffset;
 
                 float t = (float)(offset.TotalSeconds / maxOffset.TotalSeconds);
                 if (t < 0f) t = 0f;

--- a/UI/Nodes/Rounds/EventRaceNode.cs
+++ b/UI/Nodes/Rounds/EventRaceNode.cs
@@ -90,7 +90,7 @@ namespace UI.Nodes.Rounds
                     bool channelChanged = false;
 
                     Pilot pilot = null;
-                    PilotChannel pilotChannel = Race.GetPilotChannel(channel);
+                    RacePilotChannel pilotChannel = Race.GetPilotChannel(channel);
                     if (pilotChannel != null)
                     {
                         pilot = pilotChannel.Pilot;
@@ -112,9 +112,8 @@ namespace UI.Nodes.Rounds
 
                     pilotRaceInfoNode.ResultText = EventManager.ResultManager.GetResultText(Race, pilot, channel);
 
-                    if (pilot != null && !Race.Ended && Race.HandicapOffsets != null
-                        && Race.HandicapOffsets.TryGetValue(pilot.ID, out TimeSpan handicapOffset)
-                        && handicapOffset > TimeSpan.Zero)
+                    TimeSpan handicapOffset = pilotChannel?.HandicapOffset ?? TimeSpan.Zero;
+                    if (pilot != null && !Race.Ended && handicapOffset > TimeSpan.Zero)
                     {
                         string handicapText = "+" + handicapOffset.TotalSeconds.ToString("0.0") + "s";
                         if (string.IsNullOrEmpty(pilotRaceInfoNode.ResultText))

--- a/UI/Nodes/Rounds/EventRaceNode.cs
+++ b/UI/Nodes/Rounds/EventRaceNode.cs
@@ -109,6 +109,17 @@ namespace UI.Nodes.Rounds
                     container.AddChild(pilotRaceInfoNode);
 
                     pilotRaceInfoNode.ResultText = EventManager.ResultManager.GetResultText(Race, pilot, channel);
+
+                    if (pilot != null && !Race.Ended && Race.HandicapOffsets != null
+                        && Race.HandicapOffsets.TryGetValue(pilot.ID, out TimeSpan handicapOffset)
+                        && handicapOffset > TimeSpan.Zero)
+                    {
+                        string handicapText = "+" + handicapOffset.TotalSeconds.ToString("0.0") + "s";
+                        if (string.IsNullOrEmpty(pilotRaceInfoNode.ResultText))
+                            pilotRaceInfoNode.ResultText = handicapText;
+                        else
+                            pilotRaceInfoNode.ResultText += " " + handicapText;
+                    }
                 }
 
                 int size = Math.Max(grouped.Count(), 6);

--- a/UI/Nodes/Rounds/EventRaceNode.cs
+++ b/UI/Nodes/Rounds/EventRaceNode.cs
@@ -56,6 +56,8 @@ namespace UI.Nodes.Rounds
                 RoundSheetFormat sheetFormat = EventManager.RoundManager.SheetFormatManager.GetRoundSheetFormat(Race.Round);
                 int pilotCount = Race.PilotCount;
 
+                EventManager.RaceManager.ComputeHandicapOffsets(Race);
+
                 if (heading == null)
                 {
                     heading = new TextButtonNode(Race.RaceName, Theme.Current.Rounds.RaceTitle, Theme.Current.Hover.XNA, Theme.Current.Rounds.Text.XNA);

--- a/UI/Nodes/Rounds/EventRoundNode.cs
+++ b/UI/Nodes/Rounds/EventRoundNode.cs
@@ -238,7 +238,9 @@ namespace UI.Nodes.Rounds
 
             AspectRatio = 0.4f * columns;
 
-            SetHeading(RaceStringFormatter.Instance.RoundToString(Round));
+            string headingText = RaceStringFormatter.Instance.RoundToString(Round);
+            if (Round.Handicapped) headingText += "  (Handicap)";
+            SetHeading(headingText);
             UpdateButtons();
             RequestLayout();
         }

--- a/UI/Nodes/SceneManagerNode.cs
+++ b/UI/Nodes/SceneManagerNode.cs
@@ -68,6 +68,7 @@ namespace UI.Nodes
         public TimeSpan MidRaceAnimationTime { get { return TimeSpan.FromSeconds(ApplicationProfileSettings.Instance.ReOrderAnimationSeconds); } }
 
         private AutoRunnerTimerNode autoRunnerTimerNode;
+        private HandicapStartBarNode handicapStartBarNode;
 
         public Node LapTimesGraph { get; private set; }
 
@@ -141,6 +142,10 @@ namespace UI.Nodes
             fullScreenContainer = new FullScreenAspectClosable();
             fullScreenContainer.Close += UnFullScreen;
             AddChild(fullScreenContainer);
+
+            handicapStartBarNode = new HandicapStartBarNode(eventManager);
+            handicapStartBarNode.RelativeBounds = new RectangleF(0.05f, 0.92f, 0.9f, 0.045f);
+            AddChild(handicapStartBarNode);
         }
 
         private void ResultManager_RaceResultsChanged(Race obj)


### PR DESCRIPTION
Adds an opt-in handicap mode where each pilot in a round starts at a
  personal offset, calculated from PB-lap deltas so the slowest pilot
  starts first and the field theoretically converges at the finish.
  
  Three commits:

  1. **Timing pipeline** — `Round.Handicapped` flag + `HandicapCalculator`
     computes per-pilot offsets at race load. Offsets propagate through
     detection validation, lap-time math, and race-time results so each
     pilot's race is anchored to their own staggered start. Holeshot
     timing still applies inside the handicap window.
  
  2. **Audio + pre-race display** — `RaceManager` schedules per-pilot
     `OnPilotHandicapStart` events; `SoundManager` calls each pilot's
     name at their own go moment and suppresses the global "Go" cue so
     faster pilots aren't told to launch before their turn. Pre-race
     grid shows each pilot's `+N.Ns` offset.
  
  3. **Live visual cues** — Round header reads `... (Handicap)`. Each
     pilot's channel tile pulses a green "GO!" overlay at their start
     moment. A new `HandicapStartBarNode` shows a horizontal timeline
     under the video grid with channel-colored chips at each pilot's
     offset and a yellow cursor scrubbing across as the start window
     elapses. Auto-hides ~2s after the slowest pilot is away.
  
  Offsets are recomputed eagerly when the rounds view paints, so
  `+N.Ns` labels appear without needing to open the race first.