### PR TITLE
Add ExtensionNotifier (Extension Mode) — Gate / LED POST Notifications

### DIFF
--- a/ExternalData/ExtensionNotifier.cs
+++ b/ExternalData/ExtensionNotifier.cs
@@ -1,0 +1,1502 @@
+using Microsoft.Xna.Framework;
+using Newtonsoft.Json;
+using RaceLib;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Ports;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Timing;
+using Tools;
+
+namespace ExternalData
+{
+    // ExtensionNotifier
+    //
+    // Active only when ApplicationProfileSettings.ExtensionMode = true.
+    // Independent of the legacy RemoteNotifier (which is preserved verbatim).
+    // Wire format and semantics: see FT_extensions/INTERFACE.en.md / INTERFACE.ja.md.
+    public class ExtensionNotifier : IDisposable
+    {
+        private const int HttpQueueCapacity = 200;
+        private const int SerialQueueCapacity = 50;
+        private const int HttpTimeoutMs = 1500;
+        private const int SerialWriteTimeoutMs = 100;
+        private const int HelloIntervalMs = 2000;
+        private const int RecentDetectionIdsCap = 1024;
+
+        private readonly EventManager eventManager;
+        private readonly string url;
+        private readonly string comportname;
+        private readonly Profile profile;
+        private readonly string eventStorageLocation;
+        private readonly int decimalPlaces;
+
+        private WorkQueue httpQueue;
+        private WorkQueue serialQueue;
+        private int httpQueueSize;
+        private int serialQueueSize;
+
+        private HttpClient httpClient;
+        private SerialPort serialPort;
+
+        private long seqCounter;
+
+        private readonly object detectionLock = new object();
+        private readonly HashSet<Guid> recentDetectionIds = new HashSet<Guid>();
+        private readonly Queue<Guid> recentDetectionOrder = new Queue<Guid>();
+
+        private Timer helloTimer;
+        private volatile bool helloAcknowledged;
+        private volatile bool helloLogged;
+        private volatile bool disposed;
+
+        private Type lastHttpExceptionType;
+        private Type lastSerialExceptionType;
+
+        private readonly JsonSerializerSettings serializerSettings;
+
+        public ExtensionNotifier(EventManager eventManager, string url, string comportname, Profile profile, string eventStorageLocation, int decimalPlaces)
+        {
+            this.eventManager = eventManager;
+            this.url = url;
+            this.comportname = comportname;
+            this.profile = profile;
+            this.eventStorageLocation = eventStorageLocation;
+            this.decimalPlaces = decimalPlaces;
+
+            serializerSettings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.None,
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ",
+                NullValueHandling = NullValueHandling.Include,
+                // Wire format is camelCase. C# DTOs keep PascalCase property names
+                // (CLR convention); the resolver lowercases the first letter on serialize.
+                ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver()
+            };
+
+            httpQueue = new WorkQueue("ExtensionNotifier-HTTP");
+            serialQueue = new WorkQueue("ExtensionNotifier-Serial");
+
+            if (!string.IsNullOrEmpty(url))
+            {
+                // Manage the client-side connection pool ourselves so that idle
+                // connections are recycled BEFORE any receiver-side keep-alive
+                // timeout fires. 5 minutes covers a full race (max race length)
+                // so a single connection serves all detections in one race.
+                // Receivers MUST set their keep-alive timeout HIGHER than this
+                // (the test receiver uses 6 minutes).
+                var handler = new SocketsHttpHandler
+                {
+                    PooledConnectionIdleTimeout = TimeSpan.FromMinutes(5),
+                    PooledConnectionLifetime = TimeSpan.FromMinutes(30),
+                    UseProxy = false,
+                    AllowAutoRedirect = false
+                };
+                httpClient = new HttpClient(handler, disposeHandler: true)
+                {
+                    Timeout = TimeSpan.FromMilliseconds(HttpTimeoutMs),
+                    DefaultRequestVersion = System.Net.HttpVersion.Version11,
+                    DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower
+                };
+                // We do NOT set ConnectionClose=true — letting the pool reuse fresh
+                // connections is faster, and the 2s idle timeout above guarantees
+                // we never reuse a stale connection past the receiver's keep-alive.
+            }
+
+            string[] ports = SerialPort.GetPortNames();
+            if (!string.IsNullOrEmpty(comportname) && ports.Contains(comportname))
+            {
+                try
+                {
+                    serialPort = new SerialPort
+                    {
+                        BaudRate = 115200,
+                        RtsEnable = true,
+                        DtrEnable = true,
+                        WriteTimeout = SerialWriteTimeoutMs,
+                        ReadTimeout = 1,
+                        PortName = comportname
+                    };
+                    serialPort.Open();
+                }
+                catch (Exception ex)
+                {
+                    Logger.HTTP.LogException(this, ex);
+                    serialPort = null;
+                }
+            }
+
+            SubscribeRaceManager();
+            SubscribeResultManager();
+
+            StartHelloHeartbeat();
+        }
+
+        private void SubscribeRaceManager()
+        {
+            RaceManager rm = eventManager.RaceManager;
+            rm.OnRaceChanged += RaceManager_OnRaceChanged;
+            // OnRaceReset fires when the operator clears results (RaceManager.ResetRace).
+            // OnRaceChanged stays silent if the same race is then re-selected, so wire
+            // the same handler here to resupply RaceLoaded + NextRace as a fresh state
+            // snapshot. Spec §7.1: consecutive same-round/race RaceLoaded is normal.
+            rm.OnRaceReset += RaceManager_OnRaceChanged;
+            rm.OnRaceStartScheduled += RaceManager_OnRaceStartScheduled;
+            rm.OnRaceStart += RaceManager_OnRaceStart;
+            rm.OnRaceEnd += RaceManager_OnRaceEnd;
+            rm.OnRaceCancelled += RaceManager_OnRaceCancelled;
+            rm.OnRaceTimesUp += RaceManager_OnRaceTimesUp;
+            rm.OnSplitDetection += RaceManager_OnDetection;
+            rm.OnLapDetected += RaceManager_OnLapDetected;
+            rm.OnPilotAdded += RaceManager_OnPilotsChanged;
+            rm.OnPilotRemoved += RaceManager_OnPilotsChanged;
+            rm.OnChannelCrashedOut += RaceManager_OnChannelCrashedOut;
+            rm.OnPilotStartStaggered += RaceManager_OnPilotStartStaggered;
+        }
+
+        private void UnsubscribeRaceManager()
+        {
+            RaceManager rm = eventManager?.RaceManager;
+            if (rm == null) return;
+            rm.OnRaceChanged -= RaceManager_OnRaceChanged;
+            rm.OnRaceReset -= RaceManager_OnRaceChanged;
+            rm.OnRaceStartScheduled -= RaceManager_OnRaceStartScheduled;
+            rm.OnRaceStart -= RaceManager_OnRaceStart;
+            rm.OnRaceEnd -= RaceManager_OnRaceEnd;
+            rm.OnRaceCancelled -= RaceManager_OnRaceCancelled;
+            rm.OnRaceTimesUp -= RaceManager_OnRaceTimesUp;
+            rm.OnSplitDetection -= RaceManager_OnDetection;
+            rm.OnLapDetected -= RaceManager_OnLapDetected;
+            rm.OnPilotAdded -= RaceManager_OnPilotsChanged;
+            rm.OnPilotRemoved -= RaceManager_OnPilotsChanged;
+            rm.OnChannelCrashedOut -= RaceManager_OnChannelCrashedOut;
+            rm.OnPilotStartStaggered -= RaceManager_OnPilotStartStaggered;
+        }
+
+        private void SubscribeResultManager()
+        {
+            ResultManager rs = eventManager?.ResultManager;
+            if (rs != null)
+            {
+                rs.RaceResultsChanged += ResultManager_OnRaceResultsChanged;
+            }
+        }
+
+        private void UnsubscribeResultManager()
+        {
+            ResultManager rs = eventManager?.ResultManager;
+            if (rs != null)
+            {
+                rs.RaceResultsChanged -= ResultManager_OnRaceResultsChanged;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (disposed) return;
+            disposed = true;
+
+            try { helloTimer?.Dispose(); } catch { }
+            helloTimer = null;
+
+            UnsubscribeRaceManager();
+            UnsubscribeResultManager();
+
+            try { serialPort?.Close(); } catch { }
+            try { serialPort?.Dispose(); } catch { }
+            serialPort = null;
+
+            try { httpQueue?.Dispose(); } catch { }
+            httpQueue = null;
+            try { serialQueue?.Dispose(); } catch { }
+            serialQueue = null;
+
+            try { httpClient?.Dispose(); } catch { }
+            httpClient = null;
+        }
+
+        // ------------------------------------------------------------------
+        // Hello handshake
+        // ------------------------------------------------------------------
+
+        private void StartHelloHeartbeat()
+        {
+            if (httpClient == null)
+            {
+                helloAcknowledged = true;
+                return;
+            }
+
+            helloTimer = new Timer(_ => SendHello(), null, 0, HelloIntervalMs);
+        }
+
+        private async void SendHello()
+        {
+            if (helloAcknowledged || disposed || httpClient == null) return;
+
+            HelloMessage msg;
+            try { msg = BuildHello(); }
+            catch { return; }
+
+            try
+            {
+                string json = JsonConvert.SerializeObject(msg, serializerSettings);
+                using (var content = new StringContent(json, Encoding.UTF8, "application/json"))
+                using (var cts = new CancellationTokenSource(HttpTimeoutMs))
+                {
+                    var response = await httpClient.PutAsync(url, content, cts.Token).ConfigureAwait(false);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        helloAcknowledged = true;
+                        try { helloTimer?.Change(Timeout.Infinite, Timeout.Infinite); } catch { }
+                        try { helloTimer?.Dispose(); } catch { }
+                        helloTimer = null;
+                        if (!helloLogged)
+                        {
+                            helloLogged = true;
+                            Logger.HTTP.Log(this, "ExtensionNotifier handshake complete: " + url);
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Heartbeat phase: TCP refused / DNS / timeout are silently swallowed
+                // per spec §3.2 "no log noise". Only the successful handshake is logged.
+            }
+        }
+
+        private HelloMessage BuildHello()
+        {
+            string workingDir = NormalizeDir(Directory.GetCurrentDirectory());
+            string baseDir = NormalizeDir(AppDomain.CurrentDomain.BaseDirectory ?? workingDir);
+            string eventsDirRaw = string.IsNullOrEmpty(eventStorageLocation) ? "events" : eventStorageLocation;
+            string eventsDir = NormalizeDir(Path.IsPathRooted(eventsDirRaw)
+                ? eventsDirRaw
+                : Path.Combine(workingDir, eventsDirRaw));
+            string profileDir;
+            string profileName = "default";
+            try
+            {
+                profileDir = NormalizeDir(profile?.GetPath() ?? Path.Combine(workingDir, "data", profileName));
+                if (profile != null && !string.IsNullOrEmpty(profile.Name)) profileName = profile.Name;
+            }
+            catch
+            {
+                profileDir = NormalizeDir(Path.Combine(workingDir, "data", profileName));
+            }
+            string pilotsDir = NormalizeDir(Path.Combine(workingDir, "pilots"));
+
+            string version = "0.0.0.0";
+            try
+            {
+                Assembly entry = Assembly.GetEntryAssembly();
+                if (entry != null)
+                {
+                    Version v = entry.GetName().Version;
+                    if (v != null) version = v.ToString();
+                }
+            }
+            catch { }
+
+            return new HelloMessage
+            {
+                Type = "Hello",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                FpvtVersion = version,
+                Platform = DetectPlatform(),
+                Paths = new HelloPaths
+                {
+                    WorkingDirectory = workingDir,
+                    BaseDirectory = baseDir,
+                    EventsDirectory = eventsDir,
+                    ProfileDirectory = profileDir,
+                    PilotsDirectory = pilotsDir
+                },
+                Profile = new HelloProfile
+                {
+                    Name = profileName
+                },
+                DecimalPlaces = decimalPlaces,
+                TimingSystem = BuildTimingSystemInfo(),
+                EventSettings = BuildEventSettings(),
+                ChannelSettings = BuildChannelSettings()
+            };
+        }
+
+        private HelloChannelSettings BuildChannelSettings()
+        {
+            // Event-level "Channel Settings" — the channels defined for this event,
+            // independent of which pilots are assigned. Receivers use this for an
+            // un-pilot-bound channel listing (e.g. spectator OSD).
+            HelloChannelSettings s = new HelloChannelSettings { Channels = new List<ChannelInfo>() };
+            try
+            {
+                Event ev = eventManager?.Event;
+                if (ev?.Channels != null)
+                {
+                    foreach (Channel ch in ev.Channels)
+                    {
+                        if (ch == null) continue;
+                        Color color;
+                        try { color = eventManager.GetChannelColor(ch); }
+                        catch { color = Color.White; }
+                        s.Channels.Add(BuildChannel(ch, color));
+                    }
+                }
+            }
+            catch { }
+            return s;
+        }
+
+        private HelloEventSettings BuildEventSettings()
+        {
+            // Event-level race rules that affect detection interpretation. Sent on Hello
+            // so the Extension can render lap times consistently without re-reading XML.
+            HelloEventSettings s = new HelloEventSettings();
+            try
+            {
+                Event ev = eventManager?.Event;
+                if (ev != null)
+                {
+                    s.RaceStartIgnoreDetections = ev.RaceStartIgnoreDetections.TotalSeconds;
+                    s.MinLapTime = ev.MinLapTime.TotalSeconds;
+                    s.PrimaryTimingSystemLocation = ev.PrimaryTimingSystemLocation.ToString();
+                }
+            }
+            catch { }
+            return s;
+        }
+
+        private HelloTimingSystem BuildTimingSystemInfo()
+        {
+            HelloTimingSystem info = new HelloTimingSystem
+            {
+                Count = 0,
+                PrimeCount = 0,
+                SplitCount = 0,
+                SplitsPerLap = 0,
+                AllDummy = false,
+                Systems = new List<HelloTimingSystemEntry>()
+            };
+            try
+            {
+                var tsm = eventManager?.RaceManager?.TimingSystemManager;
+                if (tsm == null) return info;
+
+                info.Count = tsm.TimingSystemCount;
+                info.PrimeCount = tsm.PrimeSystems?.Length ?? 0;
+                info.SplitCount = tsm.SplitSystems?.Length ?? 0;
+                info.SplitsPerLap = tsm.SplitsPerLap;
+
+                var all = tsm.TimingSystems?.ToArray() ?? new ITimingSystem[0];
+                info.AllDummy = all.Length > 0 && all.All(t => t is DummyTimingSystem);
+
+                // Enumerate Prime systems first, then Splits, so that the indices
+                // emitted here match TimingSystemManager.GetIndex (0 = Primary,
+                // 1, 2, ... = Secondary). This is the same numbering used by
+                // Detection.TimingSystemIndex, so receivers can directly look up
+                // the role of a detection's gate via systems[detection.timingSystemIndex].
+                IEnumerable<ITimingSystem> primeFirst =
+                    (tsm.PrimeSystems ?? new ITimingSystem[0])
+                    .Concat(tsm.SplitSystems ?? new ITimingSystem[0]);
+
+                foreach (var ts in primeFirst)
+                {
+                    bool isSplit = tsm.SplitSystems != null && tsm.SplitSystems.Contains(ts);
+                    info.Systems.Add(new HelloTimingSystemEntry
+                    {
+                        Index = tsm.GetIndex(ts),
+                        Type = ts.GetType().Name,
+                        Role = isSplit ? "Split" : "Prime"
+                    });
+                }
+            }
+            catch { }
+            return info;
+        }
+
+        private static string DetectPlatform()
+        {
+            if (OperatingSystem.IsWindows()) return "Windows";
+            if (OperatingSystem.IsMacOS()) return "macOS";
+            if (OperatingSystem.IsLinux()) return "Linux";
+            return Environment.OSVersion.Platform.ToString();
+        }
+
+        private static string NormalizeDir(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return path;
+            try
+            {
+                string full = Path.GetFullPath(path);
+                if (!full.EndsWith(Path.DirectorySeparatorChar))
+                    full += Path.DirectorySeparatorChar;
+                return full;
+            }
+            catch
+            {
+                return path;
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Race lifecycle
+        // ------------------------------------------------------------------
+
+        private void RaceManager_OnRaceStartScheduled(Race race, DateTime startTime)
+        {
+            // We emit RacePreStart from OnRaceStartScheduled (not OnRacePreStart) so
+            // that scheduledStart carries the *post-randomisation* planned start
+            // moment — the exact instant RaceManager will hand off to OnRaceStart.
+            // OnRacePreStart fires earlier (inside PreRaceStart()) before the random
+            // delay between MinStartDelay and MaxStartDelay has been picked, so its
+            // timestamp would only be an upper-bound estimate. With random delays
+            // (Min != Max), receivers anchoring LED/strobe start cues to scheduledStart
+            // need the resolved value, not the worst case.
+            if (race == null) return;
+            Send(new RaceLifecycleMessage
+            {
+                Type = "RacePreStart",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString(),
+                ScheduledStart = ToUtcIso(startTime)
+            });
+        }
+
+        private void RaceManager_OnRaceChanged(Race race)
+        {
+            if (race == null) return;
+
+            Send(BuildRaceLoaded(race));
+
+            Race next;
+            try
+            {
+                next = eventManager.RaceManager.GetNextRace(true, allowCurrent: false);
+            }
+            catch
+            {
+                next = null;
+            }
+            Send(BuildNextRace(next));
+        }
+
+        private void RaceManager_OnRaceStart(Race race)
+        {
+            if (race == null) return;
+            Send(new RaceLifecycleMessage
+            {
+                Type = "RaceStart",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString(),
+                ActualStart = ToUtcIso(race.Start)
+            });
+        }
+
+        private void RaceManager_OnRaceEnd(Race race)
+        {
+            if (race == null) return;
+            Send(new RaceLifecycleMessage
+            {
+                Type = "RaceEnd",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString()
+            });
+
+            // RaceResult is emitted from ResultManager.RaceResultsChanged because
+            // ResultManager.SaveResults runs after the race ends and populates results.
+            // If for some reason that does not fire, emit a best-effort result here too.
+        }
+
+        private void RaceManager_OnRaceCancelled(Race race, bool failure)
+        {
+            if (race == null) return;
+            Send(new RaceLifecycleMessage
+            {
+                Type = "RaceCancelled",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString(),
+                Failure = failure
+            });
+        }
+
+        private void RaceManager_OnRaceTimesUp(Race race)
+        {
+            if (race == null) return;
+            Send(new RaceLifecycleMessage
+            {
+                Type = "RaceTimesUp",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString()
+            });
+        }
+
+        private void RaceManager_OnPilotsChanged(PilotChannel pc)
+        {
+            Race race = eventManager.RaceManager.CurrentRace;
+            if (race == null) return;
+
+            Send(new PilotRaceStateMessage
+            {
+                Type = "PilotRaceState",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString(),
+                Pilots = BuildPilots(race)
+            });
+        }
+
+        private void RaceManager_OnChannelCrashedOut(Channel channel, Pilot pilot, bool manual)
+        {
+            if (pilot == null) return;
+            Race race = eventManager.RaceManager.CurrentRace;
+            Color color = race != null
+                ? eventManager.GetRaceChannelColor(race, channel)
+                : eventManager.GetChannelColor(channel);
+
+            Send(new PilotCrashedOutMessage
+            {
+                Type = "PilotCrashedOut",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Pilot = BuildPilotInfo(pilot, channel, color),
+                ManuallySet = manual
+            });
+        }
+
+        // Fires once per pilot during TimeTrial staggered start, on the same
+        // worker thread that drives RaceManager.StartStaggered. Receivers light
+        // the pilot's lane / announce "<pilot> START" at this exact moment.
+        private void RaceManager_OnPilotStartStaggered(Race race, PilotChannel pc, int orderIndex, int totalPilots, TimeSpan delay)
+        {
+            if (race == null || pc?.Pilot == null || pc.Channel == null) return;
+            Color color = eventManager.GetRaceChannelColor(race, pc.Channel);
+            Send(new PilotStaggeredStartMessage
+            {
+                Type = "PilotStaggeredStart",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                Pilot = BuildPilotInfo(pc.Pilot, pc.Channel, color),
+                OrderIndex = orderIndex,
+                TotalPilots = totalPilots,
+                DelaySeconds = delay.TotalSeconds
+            });
+        }
+
+        // ------------------------------------------------------------------
+        // Detection
+        // ------------------------------------------------------------------
+
+        private void RaceManager_OnDetection(Detection det)
+        {
+            EmitDetection(det);
+        }
+
+        private void RaceManager_OnLapDetected(Lap lap)
+        {
+            if (lap?.Detection == null) return;
+            EmitDetection(lap.Detection);
+        }
+
+        private void EmitDetection(Detection det)
+        {
+            if (det == null || det.Pilot == null) return;
+
+            Race race = eventManager.RaceManager.CurrentRace;
+            if (race == null) return;
+
+            Guid id = det.ID;
+            if (id != Guid.Empty)
+            {
+                lock (detectionLock)
+                {
+                    if (recentDetectionIds.Contains(id)) return;
+                    recentDetectionIds.Add(id);
+                    recentDetectionOrder.Enqueue(id);
+                    while (recentDetectionOrder.Count > RecentDetectionIdsCap)
+                    {
+                        Guid old = recentDetectionOrder.Dequeue();
+                        recentDetectionIds.Remove(old);
+                    }
+                }
+            }
+
+            Color color = eventManager.GetRaceChannelColor(race, det.Channel);
+            int sectorCount = (eventManager.Event?.Sectors?.Length ?? 0);
+            int sectorIndex;
+            if (sectorCount > 0)
+            {
+                sectorIndex = (det.TimingSystemIndex % sectorCount) + 1;
+            }
+            else
+            {
+                // No sectors configured. Per spec §7.4 sectorIndex is 1-based and on
+                // IsLapEnd it represents the final sector of the lap — clamp to >= 1.
+                sectorIndex = Math.Max(1, det.TimingSystemIndex + 1);
+            }
+
+            TimeSpan raceTime = race.Start != default(DateTime) ? det.Time - race.Start : TimeSpan.Zero;
+            double? sectorSeconds = TryComputeSectorTime(race, det);
+            double lapTimeSoFar = TryComputeLapTimeSoFar(race, det);
+            int position = race.GetTrackPosition(det.Pilot);
+
+            bool finished = false;
+            try { finished = det.Pilot.HasFinished(eventManager, race); } catch { }
+
+            DetectionExtMessage msg = new DetectionExtMessage
+            {
+                Type = "DetectionExt",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                DetectionId = id.ToString(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                PilotName = det.Pilot.Name,
+                Channel = BuildChannel(det.Channel, color),
+                TimingSystemIndex = det.TimingSystemIndex,
+                IsLapEnd = det.IsLapEnd,
+                LapNumber = det.LapNumber,
+                SectorIndex = sectorIndex,
+                RaceSector = det.RaceSector,
+                RaceTime = raceTime.TotalSeconds,
+                SectorTime = sectorSeconds,
+                LapTimeSoFar = lapTimeSoFar,
+                Position = position,
+                Valid = det.Valid,
+                PositionSnapshot = BuildPositionSnapshot(race),
+                RaceFinishedForPilot = finished
+            };
+            Send(msg);
+        }
+
+        private static double? TryComputeSectorTime(Race race, Detection det)
+        {
+            try
+            {
+                Detection prev;
+                lock (race.Detections)
+                {
+                    prev = race.Detections
+                        .Where(d => d != det && d.Pilot == det.Pilot && d.Time < det.Time && d.Valid)
+                        .OrderByDescending(d => d.Time)
+                        .FirstOrDefault();
+                }
+                if (prev == null) return null;
+                return (det.Time - prev.Time).TotalSeconds;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static double TryComputeLapTimeSoFar(Race race, Detection det)
+        {
+            try
+            {
+                if (race.Start == default(DateTime)) return 0;
+
+                Detection lapStart;
+                lock (race.Detections)
+                {
+                    lapStart = race.Detections
+                        .Where(d => d != det && d.Pilot == det.Pilot && d.IsLapEnd && d.Time < det.Time && d.Valid)
+                        .OrderByDescending(d => d.Time)
+                        .FirstOrDefault();
+                }
+                DateTime from = lapStart?.Time ?? race.Start;
+                return (det.Time - from).TotalSeconds;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private List<PositionEntry> BuildPositionSnapshot(Race race)
+        {
+            List<PositionEntry> result = new List<PositionEntry>();
+            try
+            {
+                Pilot[] pilots;
+                lock (race.PilotChannels)
+                {
+                    pilots = race.PilotChannels
+                        .Where(pc => pc.Pilot != null)
+                        .Select(pc => pc.Pilot)
+                        .ToArray();
+                }
+
+                foreach (Pilot p in pilots)
+                {
+                    int pos = race.GetTrackPosition(p);
+                    Detection last;
+                    lock (race.Detections)
+                    {
+                        last = race.Detections
+                            .Where(d => d.Valid && d.Pilot == p)
+                            .OrderByDescending(d => d.Time)
+                            .FirstOrDefault();
+                    }
+                    int raceSector = last?.RaceSector ?? 0;
+                    double lastSec = (last != null && race.Start != default(DateTime))
+                        ? (last.Time - race.Start).TotalSeconds
+                        : 0;
+                    result.Add(new PositionEntry
+                    {
+                        PilotName = p.Name,
+                        Position = pos,
+                        RaceSector = raceSector,
+                        LastDetectionTime = lastSec
+                    });
+                }
+                result = result.OrderBy(e => e.Position).ToList();
+            }
+            catch { }
+            return result;
+        }
+
+        // ------------------------------------------------------------------
+        // ResultManager → RaceResult + StageRanking
+        // ------------------------------------------------------------------
+
+        private void ResultManager_OnRaceResultsChanged(Race race)
+        {
+            if (race == null) return;
+
+            Send(BuildRaceResult(race));
+
+            Stage stage = race.Round?.Stage;
+            if (stage != null)
+            {
+                Send(BuildStageRanking(stage));
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Builders
+        // ------------------------------------------------------------------
+
+        private RaceLoadedMessage BuildRaceLoaded(Race race)
+        {
+            return new RaceLoadedMessage
+            {
+                Type = "RaceLoaded",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString(),
+                ScheduledStart = race.ScheduledStart != default(DateTime)
+                    ? (string)ToUtcIso(race.ScheduledStart)
+                    : null,
+                TargetLaps = race.TargetLaps,
+                RaceLength = (eventManager.Event?.RaceLength ?? TimeSpan.Zero).TotalSeconds,
+                Stage = BuildStage(race.Round?.Stage),
+                Sectors = BuildSectors(),
+                Pilots = BuildPilots(race)
+            };
+        }
+
+        private NextRaceMessage BuildNextRace(Race next)
+        {
+            if (next == null)
+            {
+                return new NextRaceMessage
+                {
+                    Type = "NextRace",
+                    Ts = NowUtcIso(),
+                    Seq = NextSeq(),
+                    Round = null,
+                    Race = null,
+                    RaceType = null,
+                    ScheduledStart = null,
+                    Pilots = new List<PilotInfoExt>()
+                };
+            }
+            return new NextRaceMessage
+            {
+                Type = "NextRace",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = next.RoundNumber,
+                Race = next.RaceNumber,
+                RaceType = next.Type.ToString(),
+                ScheduledStart = next.ScheduledStart != default(DateTime)
+                    ? (string)ToUtcIso(next.ScheduledStart)
+                    : null,
+                Pilots = BuildPilots(next)
+            };
+        }
+
+        private RaceResultMessage BuildRaceResult(Race race)
+        {
+            List<PilotResultEntry> pilots = new List<PilotResultEntry>();
+            try
+            {
+                Result[] results = eventManager.ResultManager.GetOrderedResults(race).ToArray();
+
+                foreach (Result r in results)
+                {
+                    if (r.Pilot == null) continue;
+                    Channel channel = race.GetChannel(r.Pilot);
+                    Color color = channel != null ? eventManager.GetRaceChannelColor(race, channel) : Color.White;
+
+                    // GetBestLapsTime returns TimeSpan.MaxValue when the pilot doesn't
+                    // have enough valid laps for the requested count — treat that as null.
+                    double? bestLap = TryBestLap(race, r.Pilot, 1);
+
+                    int consecCount = race.TargetLaps > 0 ? Math.Min(3, race.TargetLaps) : 3;
+                    double? bestConsec = TryBestLap(race, r.Pilot, consecCount);
+
+                    pilots.Add(new PilotResultEntry
+                    {
+                        Pilot = BuildPilotInfo(r.Pilot, channel, color),
+                        Position = r.Position,
+                        TotalLaps = r.LapsFinished,
+                        TotalTime = r.Time.TotalSeconds,
+                        BestLap = bestLap,
+                        BestConsecutive = bestConsec.HasValue
+                            ? new BestConsecutiveEntry { Laps = consecCount, Time = bestConsec.Value }
+                            : null,
+                        DNF = r.DNF
+                    });
+                }
+            }
+            catch { }
+
+            return new RaceResultMessage
+            {
+                Type = "RaceResult",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString(),
+                Pilots = pilots
+            };
+        }
+
+        private StageRankingMessage BuildStageRanking(Stage stage)
+        {
+            List<StageRankingEntry> ranking = new List<StageRankingEntry>();
+            try
+            {
+                Race[] stageRaces = eventManager.RaceManager.GetRaces(r => r.Round != null && r.Round.Stage == stage && r.Valid).ToArray();
+                Pilot[] pilots = stageRaces.SelectMany(r => r.Pilots).Where(p => p != null).Distinct().ToArray();
+                Round endRound = stageRaces.OrderByDescending(r => r.RoundNumber).FirstOrDefault()?.Round;
+
+                List<Tuple<Pilot, int, double, double>> rows = new List<Tuple<Pilot, int, double, double>>();
+                foreach (Pilot p in pilots)
+                {
+                    int points = 0;
+                    try
+                    {
+                        if (endRound != null) points = eventManager.ResultManager.GetPointsTotal(endRound, p);
+                    }
+                    catch { }
+
+                    double bestLap = 0;
+                    double bestConsec = 0;
+                    foreach (Race r in stageRaces)
+                    {
+                        double? bl = TryBestLap(r, p, 1);
+                        if (bl.HasValue && (bestLap == 0 || bl.Value < bestLap)) bestLap = bl.Value;
+
+                        int cc = r.TargetLaps > 0 ? Math.Min(3, r.TargetLaps) : 3;
+                        double? bc = TryBestLap(r, p, cc);
+                        if (bc.HasValue && (bestConsec == 0 || bc.Value < bestConsec)) bestConsec = bc.Value;
+                    }
+                    rows.Add(Tuple.Create(p, points, bestLap, bestConsec));
+                }
+
+                int pos = 1;
+                int prevPoints = int.MinValue;
+                int rank = 0;
+                foreach (var row in rows.OrderByDescending(r => r.Item2))
+                {
+                    rank++;
+                    int p = row.Item2 != prevPoints ? rank : pos;
+                    pos = p;
+                    prevPoints = row.Item2;
+
+                    Race anyRace = stageRaces.FirstOrDefault(r => r.HasPilot(row.Item1));
+                    Channel ch = anyRace?.GetChannel(row.Item1);
+                    Color color = (anyRace != null && ch != null)
+                        ? eventManager.GetRaceChannelColor(anyRace, ch)
+                        : Color.White;
+
+                    int consecCount = (anyRace != null && anyRace.TargetLaps > 0) ? Math.Min(3, anyRace.TargetLaps) : 3;
+
+                    ranking.Add(new StageRankingEntry
+                    {
+                        Pilot = BuildPilotInfo(row.Item1, ch, color),
+                        Position = p,
+                        Points = row.Item2,
+                        BestLap = row.Item3 > 0 ? (double?)row.Item3 : null,
+                        BestConsecutive = row.Item4 > 0
+                            ? new BestConsecutiveEntry { Laps = consecCount, Time = row.Item4 }
+                            : null
+                    });
+                }
+            }
+            catch { }
+
+            return new StageRankingMessage
+            {
+                Type = "StageRanking",
+                Ts = NowUtcIso(),
+                Seq = NextSeq(),
+                Stage = BuildStage(stage),
+                Ranking = ranking
+            };
+        }
+
+        private List<PilotInfoExt> BuildPilots(Race race)
+        {
+            List<PilotInfoExt> list = new List<PilotInfoExt>();
+            if (race == null) return list;
+
+            PilotChannel[] pcs;
+            lock (race.PilotChannels)
+            {
+                pcs = race.PilotChannels.Where(pc => pc.Pilot != null && pc.Channel != null).ToArray();
+            }
+
+            foreach (PilotChannel pc in pcs)
+            {
+                Color color = eventManager.GetRaceChannelColor(race, pc.Channel);
+                list.Add(BuildPilotInfo(pc.Pilot, pc.Channel, color));
+            }
+            return list;
+        }
+
+        private static PilotInfoExt BuildPilotInfo(Pilot p, Channel c, Color color)
+        {
+            return new PilotInfoExt
+            {
+                Name = p?.Name,
+                Phonetic = p?.Phonetic,
+                DiscordID = p?.DiscordID,
+                PhotoPath = p?.PhotoPath,
+                VideoFlipped = p != null && p.VideoFlipped,
+                VideoMirrored = p != null && p.VideoMirrored,
+                Channel = c != null ? BuildChannel(c, color) : null
+            };
+        }
+
+        private static ChannelInfo BuildChannel(Channel c, Color color)
+        {
+            return new ChannelInfo
+            {
+                Band = c.Band.ToString(),
+                Number = c.Number,
+                Frequency = c.Frequency,
+                ColorR = color.R,
+                ColorG = color.G,
+                ColorB = color.B
+            };
+        }
+
+        private List<SectorInfoEntry> BuildSectors()
+        {
+            List<SectorInfoEntry> list = new List<SectorInfoEntry>();
+            try
+            {
+                Sector[] sectors = eventManager.Event?.Sectors;
+                if (sectors == null) return list;
+                foreach (Sector s in sectors)
+                {
+                    list.Add(new SectorInfoEntry
+                    {
+                        Number = s.Number,
+                        Length = s.Length,
+                        CalculateSpeed = s.CalculateSpeed
+                    });
+                }
+            }
+            catch { }
+            return list;
+        }
+
+        private static StageInfoEntry BuildStage(Stage stage)
+        {
+            if (stage == null) return null;
+            return new StageInfoEntry
+            {
+                Name = stage.Name,
+                StageType = stage.StageType.ToString()
+            };
+        }
+
+        // ------------------------------------------------------------------
+        // Send
+        // ------------------------------------------------------------------
+
+        private void Send(object payload)
+        {
+            if (disposed || payload == null) return;
+
+            long traceSeq = TryReadSeq(payload);
+            string traceType = TryReadType(payload) ?? payload.GetType().Name;
+
+            string json;
+            try
+            {
+                json = JsonConvert.SerializeObject(payload, serializerSettings);
+            }
+            catch (Exception ex)
+            {
+                Logger.HTTP.Log(this, "ExtSeq enter+serialize-failed seq=" + traceSeq + " type=" + traceType);
+                Logger.HTTP.LogException(this, ex);
+                return;
+            }
+
+            Logger.HTTP.Log(this, "ExtSeq enter seq=" + traceSeq + " type=" + traceType + " bytes=" + json.Length);
+
+            EnqueueHttp(json, traceSeq, traceType);
+            EnqueueSerial(json, traceSeq, traceType);
+        }
+
+        private static long TryReadSeq(object payload)
+        {
+            try
+            {
+                var p = payload.GetType().GetProperty("Seq");
+                if (p == null) return -1;
+                object v = p.GetValue(payload);
+                return v is long lv ? lv : (v is int iv ? (long)iv : -1);
+            }
+            catch { return -1; }
+        }
+
+        private static string TryReadType(object payload)
+        {
+            try
+            {
+                var p = payload.GetType().GetProperty("Type");
+                if (p == null) return null;
+                return p.GetValue(payload) as string;
+            }
+            catch { return null; }
+        }
+
+        private void EnqueueHttp(string json, long traceSeq, string traceType)
+        {
+            if (httpClient == null || string.IsNullOrEmpty(url))
+            {
+                Logger.HTTP.Log(this, "ExtSeq http-skip seq=" + traceSeq + " type=" + traceType + " (no http client)");
+                return;
+            }
+
+            int size = Interlocked.Increment(ref httpQueueSize);
+            if (size > HttpQueueCapacity)
+            {
+                Interlocked.Decrement(ref httpQueueSize);
+                Logger.HTTP.Log(this, "ExtSeq http-drop-queue-full seq=" + traceSeq + " type=" + traceType + " size=" + size);
+                return;
+            }
+
+            httpQueue.Enqueue(() =>
+            {
+                bool ok = false;
+                int status = -1;
+                System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+                try
+                {
+                    using (var content = new StringContent(json, Encoding.UTF8, "application/json"))
+                    using (var cts = new CancellationTokenSource(HttpTimeoutMs))
+                    {
+                        var task = httpClient.PutAsync(url, content, cts.Token);
+                        task.Wait();
+                        var resp = task.Result;
+                        status = (int)resp.StatusCode;
+                        ok = resp.IsSuccessStatusCode;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.HTTP.Log(this, "ExtSeq http-fail seq=" + traceSeq + " type=" + traceType + " elapsedMs=" + sw.ElapsedMilliseconds + " ex=" + e.GetType().Name + ":" + e.Message);
+                    if (lastHttpExceptionType == null || lastHttpExceptionType != e.GetType())
+                    {
+                        Logger.HTTP.LogException(this, e);
+                        lastHttpExceptionType = e.GetType();
+                    }
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref httpQueueSize);
+                }
+
+                if (ok)
+                {
+                    Logger.HTTP.Log(this, "ExtSeq http-ok seq=" + traceSeq + " type=" + traceType + " elapsedMs=" + sw.ElapsedMilliseconds + " status=" + status);
+                }
+                else if (status > 0)
+                {
+                    Logger.HTTP.Log(this, "ExtSeq http-non2xx seq=" + traceSeq + " type=" + traceType + " elapsedMs=" + sw.ElapsedMilliseconds + " status=" + status);
+                }
+            });
+        }
+
+        private void EnqueueSerial(string json, long traceSeq, string traceType)
+        {
+            if (serialPort == null) return;
+
+            int size = Interlocked.Increment(ref serialQueueSize);
+            if (size > SerialQueueCapacity)
+            {
+                Interlocked.Decrement(ref serialQueueSize);
+                Logger.HTTP.Log(this, "ExtSeq serial-drop-queue-full seq=" + traceSeq + " type=" + traceType);
+                return;
+            }
+
+            serialQueue.Enqueue(() =>
+            {
+                try
+                {
+                    byte[] bytes = Encoding.UTF8.GetBytes(json);
+                    serialPort?.Write(bytes, 0, bytes.Length);
+                }
+                catch (Exception e)
+                {
+                    if (lastSerialExceptionType == null || lastSerialExceptionType != e.GetType())
+                    {
+                        Logger.HTTP.LogException(this, e);
+                        lastSerialExceptionType = e.GetType();
+                    }
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref serialQueueSize);
+                }
+            });
+        }
+
+        // ------------------------------------------------------------------
+        // Helpers
+        // ------------------------------------------------------------------
+
+        private long NextSeq() => Interlocked.Increment(ref seqCounter);
+
+        // GetBestLapsTime returns TimeSpan.MaxValue when there are not enough valid laps.
+        // We surface that as null in the wire protocol rather than a 9.2e11-second value.
+        private static double? TryBestLap(Race race, Pilot pilot, int consecutiveLaps)
+        {
+            try
+            {
+                TimeSpan t = race.GetBestLapsTime(pilot, consecutiveLaps);
+                if (t == TimeSpan.MaxValue || t <= TimeSpan.Zero) return null;
+                return t.TotalSeconds;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string NowUtcIso() => DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+
+        private static string ToUtcIso(DateTime dt)
+        {
+            if (dt == default(DateTime)) return null;
+            DateTime utc = dt.Kind == DateTimeKind.Utc ? dt : dt.ToUniversalTime();
+            return utc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Payload DTOs
+    // ----------------------------------------------------------------------
+
+    public class HelloMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public string FpvtVersion { get; set; }
+        public string Platform { get; set; }
+        public HelloPaths Paths { get; set; }
+        public HelloProfile Profile { get; set; }
+        public int DecimalPlaces { get; set; }
+        public HelloTimingSystem TimingSystem { get; set; }
+        public HelloEventSettings EventSettings { get; set; }
+        public HelloChannelSettings ChannelSettings { get; set; }
+    }
+
+    public class HelloChannelSettings
+    {
+        // Event-level channel roster ("Channel Settings"). Each entry is a ChannelInfo
+        // (§6.1) with the event-assigned display color.
+        public List<ChannelInfo> Channels { get; set; }
+    }
+
+    public class HelloEventSettings
+    {
+        // Seconds after race start during which detections are ignored (Event setting:
+        // "Race Start Ignore Detections"). Lets the Extension match FPVTrackside's
+        // detection-validity logic when rendering live timing.
+        public double RaceStartIgnoreDetections { get; set; }
+
+        // Smart minimum lap time in seconds (Event setting: "Smart Minimum Lap Time").
+        // Detections producing a lap faster than this are filtered as duplicates.
+        public double MinLapTime { get; set; }
+
+        // "Holeshot" = goal gate sits at the start line, so the first crossing is the
+        // holeshot (lap 0 -> lap 1). "EndOfLap" = goal gate is past the start, so the
+        // first crossing IS lap 1 end (no holeshot crossing exists).
+        public string PrimaryTimingSystemLocation { get; set; }
+    }
+
+    public class HelloTimingSystem
+    {
+        public int Count { get; set; }
+        public int PrimeCount { get; set; }
+        public int SplitCount { get; set; }
+        public int SplitsPerLap { get; set; }
+        public bool AllDummy { get; set; }
+        public List<HelloTimingSystemEntry> Systems { get; set; }
+    }
+
+    public class HelloTimingSystemEntry
+    {
+        public int Index { get; set; }
+        public string Type { get; set; }
+        public string Role { get; set; }
+    }
+
+    public class HelloPaths
+    {
+        public string WorkingDirectory { get; set; }
+        public string BaseDirectory { get; set; }
+        public string EventsDirectory { get; set; }
+        public string ProfileDirectory { get; set; }
+        public string PilotsDirectory { get; set; }
+    }
+
+    public class HelloProfile
+    {
+        public string Name { get; set; }
+    }
+
+    public class RaceLifecycleMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public int Round { get; set; }
+        public int Race { get; set; }
+        public string RaceType { get; set; }
+        public string ActualStart { get; set; }
+        public string ScheduledStart { get; set; }
+        public bool? Failure { get; set; }
+
+        public bool ShouldSerializeActualStart() => ActualStart != null;
+        public bool ShouldSerializeScheduledStart() => ScheduledStart != null;
+        public bool ShouldSerializeFailure() => Failure.HasValue;
+    }
+
+    public class RaceLoadedMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public int Round { get; set; }
+        public int Race { get; set; }
+        public string RaceType { get; set; }
+        public string ScheduledStart { get; set; }
+        public int TargetLaps { get; set; }
+        public double RaceLength { get; set; }
+        public StageInfoEntry Stage { get; set; }
+        public List<SectorInfoEntry> Sectors { get; set; }
+        public List<PilotInfoExt> Pilots { get; set; }
+    }
+
+    public class NextRaceMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public int? Round { get; set; }
+        public int? Race { get; set; }
+        public string RaceType { get; set; }
+        public string ScheduledStart { get; set; }
+        public List<PilotInfoExt> Pilots { get; set; }
+    }
+
+    public class DetectionExtMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public string DetectionId { get; set; }
+        public int Round { get; set; }
+        public int Race { get; set; }
+        public string PilotName { get; set; }
+        public ChannelInfo Channel { get; set; }
+        public int TimingSystemIndex { get; set; }
+        public bool IsLapEnd { get; set; }
+        public int LapNumber { get; set; }
+        public int SectorIndex { get; set; }
+        public int RaceSector { get; set; }
+        public double RaceTime { get; set; }
+        public double? SectorTime { get; set; }
+        public double LapTimeSoFar { get; set; }
+        public int Position { get; set; }
+        public bool Valid { get; set; }
+        public List<PositionEntry> PositionSnapshot { get; set; }
+        public bool RaceFinishedForPilot { get; set; }
+    }
+
+    public class RaceResultMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public int Round { get; set; }
+        public int Race { get; set; }
+        public string RaceType { get; set; }
+        public List<PilotResultEntry> Pilots { get; set; }
+    }
+
+    public class StageRankingMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public StageInfoEntry Stage { get; set; }
+        public List<StageRankingEntry> Ranking { get; set; }
+    }
+
+    public class PilotRaceStateMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public int Round { get; set; }
+        public int Race { get; set; }
+        public string RaceType { get; set; }
+        public List<PilotInfoExt> Pilots { get; set; }
+    }
+
+    public class PilotCrashedOutMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public PilotInfoExt Pilot { get; set; }
+        public bool ManuallySet { get; set; }
+    }
+
+    public class PilotStaggeredStartMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public int Round { get; set; }
+        public int Race { get; set; }
+        public PilotInfoExt Pilot { get; set; }
+        public int OrderIndex { get; set; }
+        public int TotalPilots { get; set; }
+        public double DelaySeconds { get; set; }
+    }
+
+    public class PilotInfoExt
+    {
+        public string Name { get; set; }
+        public string Phonetic { get; set; }
+        public string DiscordID { get; set; }
+        public string PhotoPath { get; set; }
+        public bool VideoFlipped { get; set; }
+        public bool VideoMirrored { get; set; }
+        public ChannelInfo Channel { get; set; }
+    }
+
+    public class ChannelInfo
+    {
+        public string Band { get; set; }
+        public int Number { get; set; }
+        public int Frequency { get; set; }
+        public byte ColorR { get; set; }
+        public byte ColorG { get; set; }
+        public byte ColorB { get; set; }
+    }
+
+    public class PositionEntry
+    {
+        public string PilotName { get; set; }
+        public int Position { get; set; }
+        public int RaceSector { get; set; }
+        public double LastDetectionTime { get; set; }
+    }
+
+    public class StageInfoEntry
+    {
+        public string Name { get; set; }
+        public string StageType { get; set; }
+    }
+
+    public class SectorInfoEntry
+    {
+        public int Number { get; set; }
+        public double Length { get; set; }
+        public bool CalculateSpeed { get; set; }
+    }
+
+    public class PilotResultEntry
+    {
+        public PilotInfoExt Pilot { get; set; }
+        public int Position { get; set; }
+        public int TotalLaps { get; set; }
+        public double TotalTime { get; set; }
+        public double? BestLap { get; set; }
+        public BestConsecutiveEntry BestConsecutive { get; set; }
+        public bool DNF { get; set; }
+    }
+
+    public class StageRankingEntry
+    {
+        public PilotInfoExt Pilot { get; set; }
+        public int Position { get; set; }
+        public int? Points { get; set; }
+        public double? BestLap { get; set; }
+        public BestConsecutiveEntry BestConsecutive { get; set; }
+    }
+
+    public class BestConsecutiveEntry
+    {
+        public int Laps { get; set; }
+        public double Time { get; set; }
+    }
+}
+

--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -37,6 +37,10 @@ namespace RaceLib
         public event Race.OnRaceEvent OnRacePilotsSet;
 
         public event Race.OnRaceEvent OnRaceReset;
+        // Staggered start (TimeTrial + ApplicationProfileSettings.TimeTrialStaggeredStart):
+        // fires once per pilot at the instant they get the go signal inside StartStaggered.
+        // Args: race, pilot-channel, orderIndex (0-based), totalPilots, delay between pilots.
+        public event Action<Race, PilotChannel, int, int, TimeSpan> OnPilotStartStaggered;
         public event Race.OnRaceEvent OnRaceEnd;
         public event Race.OnRaceEvent OnRaceClear;
         public event Action<Race, bool> OnRaceCancelled;
@@ -695,10 +699,14 @@ namespace RaceLib
 
             OnRaceStart?.Invoke(currentRace);
 
+            int totalPilots = pilotChannels.Length;
+            int orderIndex = 0;
             foreach (PilotChannel pc in pilotChannels)
             {
                 Thread.Sleep(delay);
+                OnPilotStartStaggered?.Invoke(currentRace, pc, orderIndex, totalPilots, delay);
                 onStart(pc);
+                orderIndex++;
             }
 
             StaggeredStart = false;

--- a/UI/ApplicationProfileSettings.cs
+++ b/UI/ApplicationProfileSettings.cs
@@ -231,6 +231,11 @@ namespace UI
         [NeedsRestart]
         public bool NotificationEnabled { get; set; }
 
+        [Category("Gate / LED POST notifications")]
+        [NeedsRestart]
+        [DisplayName("Use new POST format (Extension)")]
+        public bool ExtensionMode { get; set; }
+
         [Category("Fun Stuff")]
         [NeedsRestart]
         public float SillyNameChance { get; set; }

--- a/UI/EventLayer.cs
+++ b/UI/EventLayer.cs
@@ -59,6 +59,7 @@ namespace UI
         private bool showPilotList;
 
         private ExternalData.RemoteNotifier RemoteNotifier;
+        private ExternalData.ExtensionNotifier ExtensionNotifier;
         private WorkQueue workQueueStartStopRace;
 
         private SystemStatusNode systemStatusNode;
@@ -387,9 +388,23 @@ namespace UI
 
             ControlButtons.UpdateControlButtons();
 
-            if (ApplicationProfileSettings.Instance.NotificationEnabled)
+            // ExtensionMode supersedes the legacy RemoteNotifier — running both at
+            // once would produce duplicate, conflicting traffic on the same URL/port.
+            if (ApplicationProfileSettings.Instance.NotificationEnabled
+                && !ApplicationProfileSettings.Instance.ExtensionMode)
             {
                 RemoteNotifier = new RemoteNotifier(EventManager, ApplicationProfileSettings.Instance.NotificationURL, ApplicationProfileSettings.Instance.NotificationSerialPort);
+            }
+
+            if (ApplicationProfileSettings.Instance.ExtensionMode)
+            {
+                ExtensionNotifier = new ExtensionNotifier(
+                    EventManager,
+                    ApplicationProfileSettings.Instance.NotificationURL,
+                    ApplicationProfileSettings.Instance.NotificationSerialPort,
+                    Profile,
+                    ApplicationProfileSettings.Instance.EventStorageLocation,
+                    ApplicationProfileSettings.Instance.ShownDecimalPlaces);
             }
 
             ReloadOBSRemoteControl();
@@ -563,6 +578,7 @@ namespace UI
 
             eventWebServer?.Stop();
             RemoteNotifier?.Dispose();
+            ExtensionNotifier?.Dispose();
 
             OBSRemoteControlManager?.Dispose();
 
@@ -983,7 +999,9 @@ namespace UI
                 });
 
                 // Trigger the sound. The actual race start will happen after it ends
-                SoundManager.StartRaceIn(EventManager.Event.MaxStartDelay, () =>
+                TimeSpan delay = EventManager.Event.MaxStartDelay;
+
+                SoundManager.StartRaceIn(delay, () =>
                 {
                     // Put in the queue so it definitely happens after preRaceStart
                     // Otherwise if audio is disabled it may happen before.

--- a/documentation/POST_Extension_INTERFACE.en.md
+++ b/documentation/POST_Extension_INTERFACE.en.md
@@ -1,0 +1,779 @@
+# GATE / LED POST notifications Extension Interface Specification (English)
+
+Version: 1.1  
+Direction: FPVTrackside (sender) → Extension (receiver), one-way  
+Audience: developers building Extensions or test clients
+
+This document is self-contained: a working test client can be built from this file alone.
+
+---
+
+## 1. Activation and Backward Compatibility
+
+The interface described here is active **only when** the FPVTrackside profile setting `ExtensionMode` is `true`. The setting lives under the **"Gate / LED POST notifications"** category in *Application Profile Settings*, defaults to `false`, and requires application restart to take effect.
+
+When `ExtensionMode = false`:
+- No traffic described in this document is generated.
+- Legacy `GATE / LED POST notifications` behavior (controlled by `NotificationEnabled`, `NotificationURL`, `NotificationSerialPort`) is preserved verbatim, including any pre-existing bugs.
+
+When `ExtensionMode = true`:
+- A separate component (`ExtensionNotifier`) starts and emits the events defined below.
+- Legacy `RemoteNotifier` is **suppressed** even if `NotificationEnabled = true`. ExtensionMode supersedes the legacy stream so the two never co-emit on the same URL/COM port.
+---
+
+## 2. Transport
+
+### 2.1 HTTP
+
+| Attribute | Value |
+|---|---|
+| Method | `PUT` |
+| Target URL | value of profile setting `NotificationURL` (e.g. `http://127.0.0.1:8765/`) |
+| Headers | `Content-Type: application/json; charset=utf-8` |
+| Body | exactly one JSON object per request (see §4 envelope) |
+| Connection | HTTP/1.1 keep-alive (the sender reuses one `HttpClient`) |
+| Sender timeout | 1500 ms — the request is abandoned if no response arrives in time |
+| Concurrency | one in-flight request at a time per session (events are delivered in order via a single worker queue) |
+
+### 2.2 Serial (optional)
+
+| Attribute | Value |
+|---|---|
+| Target | COM port name in profile setting `NotificationSerialPort` |
+| Baud rate | 115200 |
+| Framing | none (a single `serialPort.Write(bytes)` per event; bytes are the UTF-8 encoded JSON) |
+| Direction | **write only** — sender never reads |
+| WriteTimeout | 100 ms |
+| Behavior | fire-and-forget; failures only logged |
+| Hello | **never sent over serial** — Hello is HTTP-only |
+
+If the receiver wants to demarcate events on the serial stream, it must rely on JSON object boundaries (matching `{` … `}` with brace counting and string-aware parsing).
+
+### 2.3 IMMEDIATE RESPONSE RULE — CRITICAL
+
+The Extension **MUST** send `200 OK` **before** doing any processing of the body. The recommended handler shape is:
+
+```
+on PUT:
+    body = read_request_body()       # very fast
+    enqueue(body)                    # in-memory queue, non-blocking
+    respond 200 OK with empty body   # ← BEFORE any TTS/LED/disk/etc.
+```
+
+Why: FPVTrackside's send queue serializes events in order. If a response is delayed, every subsequent event is delayed too, up to the 1500 ms timeout per event. Under load (multiple sectors per second across many pilots), blocking on TTS or LED write would cascade into multi-second latency.
+
+The Extension SHOULD NOT:
+- Validate the body before responding (validate after).
+- Wait for downstream services (TTS engine, LED COM port, file I/O, network) before responding.
+- Return a non-empty response body (the sender ignores it; sending data wastes time).
+
+Recommended Extension architecture: one HTTP server thread that only enqueues, plus one or more worker threads that drain the queue and perform the slow work.
+
+---
+
+## 3. Hello Handshake
+
+### 3.1 Purpose
+
+1. Tell the Extension that FPVTrackside is up.
+2. Deliver FPVTrackside's filesystem paths so the Extension can resolve relative file references found in later events (e.g. `photoPath`).
+3. Allow the Extension to be started **before** FPVTrackside (the Extension waits idle until the first Hello arrives).
+
+Hello bootstraps the receiver into a **peer** of FPVTrackside rather than a passive log sink. By the time the first non-Hello event arrives, the Extension already knows where pilot media lives (`paths.pilotsDirectory`, `paths.workingDirectory`), what display precision FPVTrackside is using (`decimalPlaces`), how many sectors a lap has and which gate is the lap-loop (`timingSystem.splitsPerLap`, per-system `index`/`role`/`type`), and the exact thresholds FPVTrackside applies for holeshot and duplicate-lap filtering (`eventSettings`). A generic LED/TTS/scoreboard receiver can therefore auto-configure its sector graphics, render lap times that match the operator's screen down to the last digit, and reproduce FPVTrackside's filter decisions without diverging — none of which is possible from the legacy detection stream alone.
+
+### 3.2 Behavior on the FPVTrackside side
+
+- On `ExtensionNotifier` startup, send a Hello PUT immediately (`t = 0`).
+- If no `2xx` response is received, retry every **2000 ms**.
+- The first response with status code in the `2xx` range stops the heartbeat **permanently for that session** — there are no further Hellos until FPVTrackside is restarted.
+- Hello is sent through a dedicated `HttpClient` call, **not** through the event work queue. It does not interfere with normal event throughput.
+- Connection failures (TCP refused, DNS error, timeout) are silently swallowed during the heartbeat phase — no log noise. Only the successful handshake is logged once.
+
+### 3.3 Behavior expected on the Extension side
+
+1. On every Hello receipt, immediately respond `200 OK`.
+2. Overwrite the `fpvt` block of `config.json` (see §3.5) with the received data.
+3. Make the new paths available to the rest of the Extension before processing further events.
+4. The Hello carries no race information — no race-state changes should be triggered.
+
+### 3.4 Hello payload
+
+```json
+{
+  "type": "Hello",
+  "ts": "2026-05-03T12:34:56.789Z",
+  "seq": 1,
+  "fpvtVersion": "1.x.x",
+  "platform": "Windows",
+  "paths": {
+    "workingDirectory": "C:\\path\\to\\fpvt\\",
+    "baseDirectory":    "C:\\path\\to\\fpvt\\bin\\",
+    "eventsDirectory":  "C:\\path\\to\\fpvt\\events\\",
+    "profileDirectory": "C:\\path\\to\\fpvt\\data\\default\\",
+    "pilotsDirectory":  "C:\\path\\to\\fpvt\\pilots\\"
+  },
+  "profile": {
+    "name": "default"
+  },
+  "decimalPlaces": 2,
+  "timingSystem": {
+    "count": 4,
+    "primeCount": 1,
+    "splitCount": 3,
+    "splitsPerLap": 4,
+    "allDummy": false,
+    "systems": [
+      { "index": 0, "type": "LapRFTimingSystem", "role": "Prime" },
+      { "index": 1, "type": "LapRFTimingSystem", "role": "Split" },
+      { "index": 2, "type": "LapRFTimingSystem", "role": "Split" },
+      { "index": 3, "type": "LapRFTimingSystem", "role": "Split" }
+    ]
+  },
+  "eventSettings": {
+    "raceStartIgnoreDetections": 0.5,
+    "minLapTime": 5.0,
+    "primaryTimingSystemLocation": "EndOfLap"
+  },
+  "channelSettings": {
+    "channels": [
+      { "band": "Raceband", "number": 1, "frequency": 5658, "colorR": 255, "colorG": 0, "colorB": 0 },
+      { "band": "Raceband", "number": 2, "frequency": 5695, "colorR": 0, "colorG": 255, "colorB": 0 }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | always `"Hello"` |
+| `ts` | string | ISO-8601 UTC, millisecond precision |
+| `seq` | int64 | monotonic counter (see §5) |
+| `fpvtVersion` | string | FPVTrackside version string |
+| `platform` | string | `"Windows"` \| `"macOS"` \| `"Linux"` |
+| `paths.workingDirectory` | string (absolute) | `Directory.GetCurrentDirectory()`. **Base for resolving every relative path in later events** (notably `photoPath`). |
+| `paths.baseDirectory` | string (absolute) | `AppDomain.CurrentDomain.BaseDirectory` — where the FPVTrackside binary lives. |
+| `paths.eventsDirectory` | string (absolute) | Resolved from setting `EventStorageLocation`. If that setting is relative, it is resolved against `workingDirectory`. |
+| `paths.profileDirectory` | string (absolute) | Profile-specific data directory: `<workingDirectory>/data/<profileName>/`. Contains `ProfileSettings.xml` and other per-profile state. |
+| `paths.pilotsDirectory` | string (absolute) | `<workingDirectory>/pilots/`. Pilot media (photos and videos). |
+| `profile.name` | string | Active profile name. Constant for the lifetime of the FPVTrackside session. |
+| `decimalPlaces` | int | `ApplicationProfileSettings.ShownDecimalPlaces`. Recommended number of fractional digits when the Extension renders durations (lap times, sector times) as text. The Extension is free to override but should default to this value to match what FPVTrackside displays. |
+| `timingSystem.count` | int | Total number of timing systems **configured** (Prime + Split). Independent of connection state. |
+| `timingSystem.primeCount` | int | Number of "Prime" systems (lap-loop detectors). Normally 1. |
+| `timingSystem.splitCount` | int | Number of "Split" systems (intermediate sector detectors). |
+| `timingSystem.splitsPerLap` | int | **Sectors per lap.** Equals `splitCount + 1`. The "+1" accounts for the lap-end detection at the Prime system, which is itself the last sector of the lap. |
+| `timingSystem.allDummy` | bool | True if every configured system is a dummy/simulated timer. Computed from configured types only — does **not** require connections. |
+| `timingSystem.systems[]` | array | Per-system list. **Index numbering matches `DetectionExt.timingSystemIndex` exactly**: index `0` is the Prime (lap-loop) system, indices `1..splitCount` are Split (intermediate) systems in sector traversal order. The array is ordered by `index` ascending. Each entry: `index` (0-based), `type` (C# class name e.g. `"LapRFTimingSystem"`, `"DummyTimingSystem"`), `role` (`"Split"` or `"Prime"`). Receivers can look up the role of a detection's gate via `systems[detection.timingSystemIndex]`. |
+| `eventSettings.raceStartIgnoreDetections` | number (seconds) | Event setting "Race Start Ignore Detections". Detections within this many seconds after `RaceStart.actualStart` are filtered by FPVTrackside. The Extension can use this to display "settling" indicators during the early race. |
+| `eventSettings.minLapTime` | number (seconds) | Event setting "Smart Minimum Lap Time". Lap times faster than this are filtered as duplicate detections by FPVTrackside. |
+| `eventSettings.primaryTimingSystemLocation` | string | Event setting "Primary Timing System Location". One of `"Holeshot"` or `"EndOfLap"`. `Holeshot` = the lap-loop sits at the start line, so the very first lap-end crossing is a holeshot (lap 0 → lap 1 transition, not a real lap). `EndOfLap` = the lap-loop is past the start line, so the first lap-end crossing IS the end of lap 1 (no holeshot exists). The Extension uses this to decide whether to display / suppress the holeshot crossing. |
+| `channelSettings.channels[]` | ChannelInfo[] | Event-level "Channel Settings": the channels defined for this event. Each entry is a §6.1 `ChannelInfo`. `colorR/G/B` are the per-event assigned display colors. Receivers can use this for un-assigned channel rendering or non-race channel listings. |
+
+The `timingSystem` block describes the **configured topology** as known to FPVTrackside at Hello-send time. Connection state is intentionally excluded: at FPVTrackside startup most systems are still negotiating, so a connected/disconnected flag at this point would be misleading. The Extension can rely on `count`, `splitsPerLap`, and the per-system `index`/`role`/`type` for routing logic.
+
+All paths are absolute, fully resolved (no `..` segments), and use the host OS path separator (backslash on Windows, forward slash elsewhere). They are guaranteed to refer to the same locations the running FPVTrackside instance is using.
+
+### 3.5 Extension `config.json` schema
+
+The Extension persists the FPVTrackside connection state so that historical data remains accessible while FPVTrackside is offline.
+
+```json
+{
+  "fpvt": {
+    "lastHelloAt": "2026-05-03T12:34:56.789Z",
+    "fpvtVersion": "1.x.x",
+    "platform": "Windows",
+    "paths": {
+      "workingDirectory": "...",
+      "baseDirectory":    "...",
+      "eventsDirectory":  "...",
+      "profileDirectory": "...",
+      "pilotsDirectory":  "..."
+    },
+    "profile": { "name": "default" },
+    "decimalPlaces": 2,
+    "timingSystem": { "...": "see §3.4" }
+  },
+  "extension": {
+    "ledComPort": "COM5",
+    "ttsEngine": "...",
+    "...": "..."
+  }
+}
+```
+
+Rules:
+- The Extension overwrites the **entire `fpvt` block** on every Hello — never merge field-by-field, because path layout may change between sessions.
+- The Extension MUST preserve the `extension` block (and any other top-level keys) across Hello updates.
+- Write atomically (write to a temp file then rename) to survive crashes.
+- If `config.json` does not exist on first Hello, create it.
+
+### 3.6 Path resolution example
+
+A pilot record in a later event contains:
+```json
+"photoPath": "pilots/jdoe/jdoe.mp4"
+```
+The Extension resolves to:
+```
+absolutePath = path.join(config.fpvt.paths.workingDirectory, pilot.photoPath)
+             = "C:\path\to\fpvt\pilots\jdoe\jdoe.mp4"   (on Windows)
+```
+
+If `photoPath` is empty/null, the pilot has no media and no resolution should be attempted.
+
+---
+
+## 4. Common envelope
+
+Every event — including Hello — uses this top-level shape:
+
+```json
+{
+  "type": "<event-name>",
+  "ts": "<ISO-8601 UTC, ms>",
+  "seq": <int64>,
+  "...": "type-specific fields"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | Event discriminator. Use this and only this to dispatch handlers. |
+| `ts` | string | Sender's UTC timestamp at the moment the event was created (NOT when it was sent). Format: ISO-8601 with millisecond precision and `Z` suffix. |
+| `seq` | int64 | See §5. |
+
+Type-specific fields are **siblings** of `type`/`ts`/`seq`, not nested under a wrapper.
+
+---
+
+## 5. Sequence numbers and ordering
+
+- `seq` is a monotonically increasing 64-bit integer assigned by the sender.
+- It starts at 1 on FPVTrackside startup and is incremented (atomically) for every event, including Hello.
+- Within one FPVTrackside session, `seq` never decreases and never repeats.
+- Across FPVTrackside restarts, `seq` resets to 1. The Extension can detect a restart by observing `seq` going backwards (or by the new Hello arriving).
+- Events are delivered **in order** by the sender (single worker queue per transport). The Extension's own queueing must also preserve order if order matters for processing.
+- The Extension MAY use `seq` to detect lost or duplicate events and to log misordering.
+
+---
+
+## 6. Sub-objects (shared across events)
+
+These structures are referenced by multiple event types.
+
+### 6.1 `ChannelInfo`
+
+```json
+{
+  "band": "E",
+  "number": 1,
+  "frequency": 5705,
+  "colorR": 255,
+  "colorG": 64,
+  "colorB": 64
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `band` | string | Raw C# `Band` enum name. One of: `Fatshark`, `Raceband`, `A`, `B`, `E`, `DJIFPVHD`, `SharkByte` (alias `HDZero`, same enum value), `LowBand`, `Diatone`, `DJIO3`, `DJIO4`, `WalkSnail`, or `None` for an unassigned channel. New bands may be added in future FPVTrackside versions; receivers MUST treat the value as an opaque string and not assume the list is closed. |
+| `number` | int | 1..8 typical |
+| `frequency` | int | MHz |
+| `ColorR/G/B` | int (0..255) | Display color assigned for this channel in this race |
+
+### 6.2 `PilotInfoExt`
+
+Used wherever a pilot is described, INCLUDING `RaceLoaded`, `NextRace`, `RaceResult`, `PilotRaceState`, `PilotCrashedOut`.
+
+```json
+{
+  "name": "John Doe",
+  "phonetic": "jon doh",
+  "discordID": "jdoe#1234",
+  "photoPath": "pilots/jdoe/jdoe.mp4",
+  "videoFlipped": false,
+  "videoMirrored": false,
+  "channel": { "...": "ChannelInfo, see §6.1" }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Pilot display name |
+| `phonetic` | string | TTS pronunciation hint. May be auto-generated from `name` if not explicitly set. |
+| `discordID` | string \| null | Optional |
+| `photoPath` | string \| null | **Relative path** from `paths.workingDirectory`. The field name says "Photo" but it commonly holds video files (e.g. `.mp4`). May be empty. |
+| `videoFlipped` | bool | Display the media upside down. |
+| `videoMirrored` | bool | Mirror left/right. |
+| `channel` | ChannelInfo | Channel allocated to this pilot in this race |
+
+### 6.3 `PositionEntry`
+
+A single row in a position snapshot — see §7.4.
+
+```json
+{
+  "pilotName": "John Doe",
+  "position": 1,
+  "raceSector": 14,
+  "lastDetectionTime": 23.456
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `pilotName` | string | Identifies the pilot by display name |
+| `position` | int | 1-based; ties may share a position (see §7.4) |
+| `raceSector` | int | Cumulative sector index reached, encoded as `lap × 100 + timingSystemIndex` (see §7.4 and Glossary). Higher = further. |
+| `lastDetectionTime` | number (seconds) | Seconds since race start of the last detection used to place this pilot. `0` if not yet detected. |
+
+### 6.4 `StageInfo`
+
+```json
+{
+  "name": "Qualifying",
+  "stageType": "Default"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Stage display name |
+| `stageType` | string | One of `Default`, `DoubleElimination`, `Final`, `StreetLeague`, `ChaseTheAce` (raw enum name) |
+
+May be `null` if the current race's round has no stage.
+
+### 6.5 `SectorInfo`
+
+```json
+{
+  "number": 1,
+  "length": 0.0,
+  "calculateSpeed": false
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `number` | int | 1-based sector number on the track |
+| `length` | number | Sector length in meters (0 if unknown) |
+| `calculateSpeed` | bool | Whether speed is calculated for this sector |
+
+The lap-end "sector" is implicit — it is the last detection of a lap loop.
+
+### 6.6 `PilotResultEntry`
+
+Used in `RaceResult.Pilots[]`.
+
+```json
+{
+  "pilot": { "...": "PilotInfoExt, see §6.2" },
+  "position": 1,
+  "totalLaps": 5,
+  "totalTime": 123.456,
+  "bestLap": 22.345,
+  "bestConsecutive": { "laps": 3, "time": 67.890 },
+  "dnf": false
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `pilot` | PilotInfoExt | Full pilot info including media paths |
+| `position` | int | Final position in this race (1-based) |
+| `totalLaps` | int | Number of valid laps completed |
+| `totalTime` | number (seconds) | Total race time used (race time when finished, or full race length if DNF) |
+| `bestLap` | number (seconds) \| null | Best single lap time |
+| `bestConsecutive` | object \| null | Best consecutive-laps time. `laps` is the consecutive count configured for the event (often 3). `null` if not applicable. |
+| `dnf` | bool | True if the pilot did not finish |
+
+### 6.7 `StageRankingEntry`
+
+Used in `StageRanking.Ranking[]`.
+
+```json
+{
+  "pilot": { "...": "PilotInfoExt" },
+  "position": 1,
+  "points": 12,
+  "bestLap": 22.345,
+  "bestConsecutive": { "laps": 3, "time": 67.890 }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `pilot` | PilotInfoExt | |
+| `position` | int | Position within the stage (1-based) |
+| `points` | int \| null | Cumulative stage points if the event uses points scoring; otherwise null |
+| `bestLap` | number (seconds) \| null | Stage-best single lap |
+| `bestConsecutive` | object \| null | Stage-best consecutive laps |
+
+---
+
+## 7. Event types
+
+This section lists every `type` value the Extension may receive (other than `Hello`, defined in §3).
+
+### 7.1 `RaceLoaded`
+
+Fires when the current race changes (a new race is loaded into the manager). Arrives before `RacePreStart`.
+
+**Also re-fires immediately after `RaceManager.ResetRace`** — the reset race is passed back through `RaceLoaded` even when the operator re-selects the same race. Because clearing results can stale the receiver's pilot dictionary and derived state, this re-fire pairs with the `RaceResult.pilots=[]` "results invalidated" signal to resupply the full state. Receivers must treat this as an idempotent state replace (consecutive deliveries of the same `round`/`race` are normal, not an error).
+
+```json
+{
+  "type": "RaceLoaded",
+  "ts": "...",
+  "seq": 42,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "scheduledStart": "2026-05-03T13:00:00.000Z",
+  "targetLaps": 5,
+  "raceLength": 120.0,
+  "stage": { "...": "StageInfo or null" },
+  "sectors": [ { "...": "SectorInfo" }, ... ],
+  "pilots": [ { "...": "PilotInfoExt" }, ... ]
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `round` | int | Round number |
+| `race` | int | Race number within the round |
+| `raceType` | string | `race` / `TimeTrial` / `AggregateLaps` / `Game` / etc. (raw enum name) |
+| `scheduledStart` | string (ISO-8601 UTC) \| null | The scheduled start time, if set. The Extension uses this for pre-race countdown animation. |
+| `targetLaps` | int | Configured lap count for the race (0 if time-based only) |
+| `raceLength` | number (seconds) | Configured race duration (0 if lap-based only) |
+| `stage` | StageInfo \| null | Stage of the round, if any |
+| `sectors` | SectorInfo[] | Track sector configuration. The lap-end "sector" is implicit and not listed here. |
+| `pilots` | PilotInfoExt[] | All pilots assigned to this race with their channels |
+
+### 7.2 `NextRace`
+
+Fires when the current race changes, providing the **next** race in sequence (the one after the just-loaded race). Used to drive pilot introductions for the upcoming race.
+
+```json
+{
+  "type": "NextRace",
+  "ts": "...",
+  "seq": 43,
+  "round": 3,
+  "race": 3,
+  "raceType": "Race",
+  "scheduledStart": "2026-05-03T13:05:00.000Z",
+  "pilots": [ { "...": "PilotInfoExt" }, ... ]
+}
+```
+
+If there is no next race, the event is sent with `round`/`race` = `null` and `pilots` = `[]`.
+
+### 7.3 `RacePreStart` / `RaceStart` / `RaceEnd` / `RaceCancelled` / `RaceTimesUp`
+
+Lifecycle events. All share the same body.
+
+```json
+{
+  "type": "RacePreStart",
+  "ts": "...",
+  "seq": 44,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "scheduledStart": "2026-05-03T13:00:05.000Z",
+  "actualStart": "2026-05-03T13:00:07.345Z"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `round` | int | |
+| `race` | int | |
+| `raceType` | string | |
+| `scheduledStart` | string (ISO-8601 UTC) \| null | Present on `RacePreStart` only. The **planned start time** determined when the countdown begins. |
+| `actualStart` | string (ISO-8601 UTC) \| null | Present on `RaceStart` only. The **actual start moment** when the race officially begins. |
+| `failure` | bool | Present on `RaceCancelled` only. True if cancelled due to system failure rather than operator action. |
+
+The five `type` values:
+- `RacePreStart` — race armed, **the randomised start time has just been resolved**, countdown about to begin. **Includes `scheduledStart`.** Fires from `RaceManager.OnRaceStartScheduled` (not `OnRacePreStart`), so the timestamp is the post-randomisation planned moment, not an upper-bound estimate.
+- `RaceStart` — countdown over, race timer starts now. **Includes `actualStart`.**
+- `RaceTimesUp` — race time elapsed (does not necessarily end the race; pilots may still be completing the in-progress lap)
+- `RaceEnd` — race over (all pilots finished or stopped)
+- `RaceCancelled` — race aborted
+
+`RacePreStart.scheduledStart` is the **exact planned start instant** chosen by `StartRaceInLessThan(MinStartDelay, MaxStartDelay)` — a uniformly distributed pick in `[Now + MinStartDelay, Now + MaxStartDelay]`. The value is delivered before the wait loop runs, so receivers have the full random window (~`MaxStartDelay − MinStartDelay`, minus a few network/serial milliseconds) to prepare their start cues. This is particularly valuable for **accessibility** scenarios: a pilot who is deaf, hard-of-hearing, or running with ambient noise that masks the audio "GO" beep can rely on an LED panel or strobe anchored to `scheduledStart`, getting the same fair start signal as every other pilot — even when the event uses randomised start delays (`MinStartDelay != MaxStartDelay`). Operators can also audit race-start jitter after the fact by comparing `scheduledStart` (from `RacePreStart`) with `actualStart` (from `RaceStart`).
+
+### 7.4 `DetectionExt`
+
+The most frequent event. Fires once per gate detection (sector pass or lap end). Replaces the legacy `DetectionDetails` for Extension purposes; both may be present on the wire when the legacy notifier is also enabled.
+
+Compared to legacy `DetectionDetails`, `DetectionExt` ships several pre-computed fields that previously had to be derived by the receiver:
+
+- **`sectorTime`** — time spent in the sector that ended at this detection. Legacy delivered only the cumulative `Time`, forcing receivers to remember each pilot's previous detection and compute deltas (with no defense against missed events).
+- **`positionSnapshot[]`** — full leaderboard at this instant (every pilot, not just the detected one), already ordered by `Race.GetTrackPosition`. Legacy carried only the detected pilot's own `Position`.
+- **`raceFinishedForPilot`**, **`valid`**, **`lapTimeSoFar`**, **`raceSector`** — race-completion flag, filter-validity flag, in-progress lap time, and the cumulative ordering key.
+- **`round` / `race` / `raceType`** — each detection identifies its own race, so receivers no longer have to correlate against the most recent `RaceState`.
+
+**De-duplication**: the sender filters by detection ID so the same detection is never emitted twice in this event type, even if FPVTrackside internally fires both `OnSplitDetection` and `OnLapDetected` for the same underlying detection. (Legacy `RemoteNotifier` did **not** deduplicate, so every lap-loop crossing was delivered twice — receivers were responsible for filtering.)
+
+```json
+{
+  "type": "DetectionExt",
+  "ts": "...",
+  "seq": 99,
+  "detectionId": "1f8a2c3d-...",
+  "round": 3,
+  "race": 2,
+  "pilotName": "John Doe",
+  "channel": { "...": "ChannelInfo" },
+  "timingSystemIndex": 0,
+  "isLapEnd": false,
+  "lapNumber": 2,
+  "sectorIndex": 1,
+  "raceSector": 7,
+  "raceTime": 38.421,
+  "sectorTime": 5.123,
+  "lapTimeSoFar": 18.234,
+  "position": 2,
+  "valid": true,
+  "positionSnapshot": [ { "...": "PositionEntry" }, ... ],
+  "raceFinishedForPilot": false
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `detectionId` | string (GUID) | Unique ID. Use to suppress duplicates if needed. |
+| `round`, `race` | int | Race identification |
+| `pilotName` | string | |
+| `channel` | ChannelInfo | |
+| `timingSystemIndex` | int | Index of the timing system (0-based) that produced the detection — this corresponds to a physical gate. |
+| `isLapEnd` | bool | True for the lap-loop crossing; false for intermediate sectors. |
+| `lapNumber` | int | 0-based lap currently being run (or just completed if `isLapEnd`). |
+| `sectorIndex` | int | Within-lap sector index (1-based). Computed as `(timingSystemIndex % splitsPerLap) + 1` (or `Max(1, timingSystemIndex + 1)` when no inner sectors are configured). Because the Prime/lap-loop system has `timingSystemIndex=0`, **its `sectorIndex` is `1`** — interpret a lap-end crossing as "S1 of the next lap", not "the final sector of the just-completed lap". Receivers that need an "end-of-lap" sector label should derive it from `splitsPerLap` and `isLapEnd`, not from this field. |
+| `raceSector` | int | Cumulative sector index since race start, encoded as `lap × 100 + timingSystemIndex`. Note: the `100` is a fixed multiplier (not `splitsPerLap`) and the index portion is the raw 0-based `timingSystemIndex` (Goal = 0), **not** the 1-based `sectorIndex` field above. Requires `splitsPerLap ≤ 100` for ordering to be unambiguous. Used internally for ordering — same value as `PositionEntry.raceSector`. |
+| `raceTime` | number (seconds) | Seconds since `RaceStart.actualStart` for this detection. |
+| `sectorTime` | number (seconds) \| null | Time taken to traverse the sector that ended at this detection. `null` if no preceding detection exists for this pilot in this lap (e.g. holeshot). |
+| `lapTimeSoFar` | number (seconds) | Time elapsed in the current lap (or final lap time if `isLapEnd`). |
+| `position` | int | This pilot's position at this exact detection moment. |
+| `valid` | bool | False if the detection was filtered out by the timing system or rules (still emitted for visibility). |
+| `positionSnapshot` | PositionEntry[] | **All** pilots' positions at this detection moment. Pre-computed by FPVTrackside from `Race.GetTrackPosition()`, which already accounts for sector progress (a pilot deeper into the lap is ahead). The Extension does **not** need to recompute. Length = number of pilots in the race. |
+| `raceFinishedForPilot` | bool | True iff this detection is the last one this pilot will produce in this race (target lap reached, etc.). |
+
+**Position semantics** (matches `Race.GetTrackPosition`):
+- Pilots ordered first by `raceSector` descending (further along the course is ahead), then by detection time ascending (earlier detection at same sector is ahead).
+- Ties (same sector, same time) may share a position; the lower-positioned pilot's `position` is duplicated. Receivers should accept that two entries may have `Position == 1`.
+
+### 7.5 `RaceResult`
+
+Fires whenever `ResultManager` reports a result change for a race. Two contexts:
+
+1. **End-of-race finalization** — fired **immediately before `RaceEnd`** (not after). The typical end-of-race sequence is `RaceResult` → `StageRanking` (if the race belongs to a stage) → `RaceEnd`. Treat `RaceResult` as a leading indicator that the race is wrapping up; do not wait for `RaceEnd` to render results.
+2. **Result clear** — fired when the race's stored results are cleared. This happens during `RaceManager.ResetRace` (operator action) and also automatically at FPVTrackside startup when a previously-run race is reloaded into the manager. In this case `pilots` is **empty (`[]`)** and the event is essentially a "results invalidated" signal.
+
+```json
+{
+  "type": "RaceResult",
+  "ts": "...",
+  "seq": 150,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "pilots": [ { "...": "PilotResultEntry" }, ... ]
+}
+```
+
+`pilots` is sorted ascending by `position`. DNF pilots appear at the bottom. **`pilots` is `[]` when the event represents a result clear** — receivers that render a result UI should treat an empty list as "clear the display" rather than "0 pilots finished".
+
+### 7.6 `StageRanking`
+
+Fires when stage ranking changes (after `ResultManager` recomputes results), but **only** when the just-finished race belongs to a stage (`Race.Round.Stage != null`).
+
+```json
+{
+  "type": "StageRanking",
+  "ts": "...",
+  "seq": 160,
+  "stage": { "...": "StageInfo" },
+  "ranking": [ { "...": "StageRankingEntry" }, ... ]
+}
+```
+
+`ranking` is sorted ascending by `position`. Like `RaceResult` (§7.5), this event also fires when results are cleared (race reset or startup re-load); in that case `ranking` may be empty or contain entries with zero/null aggregates — treat it as a "stage ranking invalidated" signal.
+
+### 7.7 `PilotCrashedOut`
+
+Fires when a pilot is marked crashed out (manually by the race director or automatically by static-detection).
+
+```json
+{
+  "type": "PilotCrashedOut",
+  "ts": "...",
+  "seq": 110,
+  "pilot": { "...": "PilotInfoExt" },
+  "manuallySet": true
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `pilot` | PilotInfoExt | Includes channel and media paths |
+| `manuallySet` | bool | True = race director, False = automatic detection |
+
+### 7.8 `PilotRaceState`
+
+Fires when pilots are added to or removed from the current race (e.g., late additions).
+
+```json
+{
+  "type": "PilotRaceState",
+  "ts": "...",
+  "seq": 35,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "pilots": [ { "...": "PilotInfoExt" }, ... ]
+}
+```
+
+`pilots` is the **complete current roster** of the race after the change — not just the added/removed pilot.
+
+### 7.9 `PilotStaggeredStart`
+
+Fires only when a TimeTrial race runs with FPVTrackside's "Time Trial Staggered Start" enabled. `RaceManager.StartStaggered` starts each pilot in turn; this event is emitted **at the exact instant the pilot gets the go signal**, once per pilot.
+
+```json
+{
+  "type": "PilotStaggeredStart",
+  "ts": "...",
+  "seq": 47,
+  "round": 1,
+  "race": 3,
+  "pilot": { "...": "PilotInfoExt (§6.2)" },
+  "orderIndex": 0,
+  "totalPilots": 4,
+  "delaySeconds": 3.0
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `round` / `race` | int | Race identifiers |
+| `pilot` | PilotInfoExt | The pilot getting the go signal. `pilot.channel.colorR/G/B` can be sent straight to LED hardware. |
+| `orderIndex` | int | 0-based start order. `0` is the first pilot to go. |
+| `totalPilots` | int | Number of pilots in the staggered start for this race. |
+| `delaySeconds` | number (seconds) | Inter-pilot start delay. Each pilot's go moment is `RaceStart.actualStart + (orderIndex+1) * delaySeconds`. |
+
+**Start order**: ascending by event-wide best-time rank (`LapRecordManager.GetTimePosition`), then ascending by channel frequency as a tiebreaker. In the first heat (no PB yet), every pilot has the same rank and frequency-order applies.
+
+**Not emitted for other start modes**:
+- Simultaneous start (regular Race) → `RaceStart` alone is sufficient.
+- Delayed start (`MinStartDelay` / `MaxStartDelay`) → `RacePreStart` + `RaceStart` carry everything.
+
+The arrival of this event itself is the staggered-start signal for receivers. No staggered flag is sent in Hello.
+
+---
+
+## 8. Time and number formats
+
+- All wall-clock timestamps (`ts`, `scheduledStart`, `actualStart`): ISO-8601 UTC, millisecond precision, `Z` suffix. Example: `2026-05-03T12:34:56.789Z`.
+- All durations (`sectorTime`, `lapTimeSoFar`, `raceTime`, `bestLap`, `bestConsecutive.time`, `totalTime`, `raceLength`): JSON numbers in **seconds**, fractional. No `TimeSpan` strings.
+- All positions and counts: JSON integers. 1-based unless noted.
+- Booleans: JSON `true`/`false`, never `0`/`1`.
+- Strings are UTF-8 in the JSON payload.
+
+---
+
+## 9. Failure semantics
+
+- The sender does not retry events on HTTP failure. A timeout, connection error, or non-2xx response causes the event to be dropped silently (logged once per error type).
+- The sender's HTTP queue capacity is 200 events. If the queue is full, **new events are dropped** (not the oldest). Under normal Extension behavior (immediate ack, async processing) this never occurs.
+- The sender's serial queue capacity is 50 events with the same drop policy.
+- The Extension cannot request a resync. If events are missed, the Extension recovers state at the next `RaceLoaded`/`RaceResult`/`StageRanking`.
+- Hello retries until first 2xx; after that, never retries within the session.
+
+---
+
+## 10. Receiver requirements summary
+
+A conforming Extension(The external applications you create) MUST:
+
+1. Listen for HTTP `PUT` on the URL configured in FPVTrackside's `NotificationURL`.
+2. Respond `200 OK` (empty body) **before** processing the request body.
+3. Parse the JSON, dispatch on the `type` field.
+4. **Silently ignore** unknown `type` values (return 200 OK as normal). Measures to address the possibility of unknown `type`s being added in the future.
+5. On `Hello`: persist `paths` and `profile` (along with `decimalPlaces` and `timingSystem`) into `config.json`'s `fpvt` block atomically.
+6. Resolve `photoPath` and any other relative paths against `config.fpvt.paths.workingDirectory`.
+7. Tolerate `seq` resets (treat any decreasing `seq` as a sender restart; log but do not crash).
+8. Tolerate duplicate `detectionId` (deduplicate defensively, even though the sender filters).
+
+A conforming Extension SHOULD:
+
+- Run the slow work (TTS, LED writes, file scans) on threads other than the HTTP handler.
+- Cache `paths` from the last Hello so that historical event-data scans work even when FPVTrackside is offline.
+- Log unexpected fields and unknown `type` values at debug level for diagnosis.
+
+---
+
+## 11. Minimal test client (pseudocode)
+
+```
+config = read_or_default("config.json")
+
+server = http.create_server(handle)
+server.listen(config.extension?.port ?? 8765)
+
+queue = bounded_queue(1000)
+spawn worker(queue)
+
+def handle(request, response):
+    body = request.read_body_sync()       # cheap
+    response.send(200)                    # ★ ack first
+    queue.try_enqueue(body)               # drop if full (logged)
+
+def worker(queue):
+    while true:
+        body = queue.dequeue()
+        evt = json.parse(body)
+        match evt.type:
+            "Hello":
+                config.fpvt = {
+                  "lastHelloAt":               evt.ts,
+                  "fpvtVersion":               evt.fpvtVersion,
+                  "platform":                  evt.platform,
+                  "paths":                     evt.paths,
+                  "profile":                   evt.profile,
+                  "decimalPlaces":             evt.decimalPlaces,
+                  "timingSystem":              evt.timingSystem,
+                  "eventSettings":             evt.eventSettings
+                }
+                write_atomic("config.json", config)
+            "RaceLoaded":   on_race_loaded(evt)
+            "NextRace":     on_next_race(evt)
+            "RacePreStart" | "RaceStart" | "RaceTimesUp" | "RaceEnd" | "RaceCancelled":
+                on_race_lifecycle(evt)
+            "DetectionExt": on_detection(evt)
+            "RaceResult":   on_result(evt)
+            "StageRanking": on_stage_ranking(evt)
+            "PilotCrashedOut": on_crash(evt)
+            "PilotRaceState":  on_roster_change(evt)
+            _: log_debug("ignored type:", evt.type)
+```
+
+This is enough to receive every event, persist `config.json`, and dispatch handlers. Each `on_*` handler can resolve media paths via `path.join(config.fpvt.paths.workingDirectory, pilot.photoPath)` and trigger LED/TTS as needed.
+
+---
+
+## 12. Glossary
+
+| Term | Meaning |
+|---|---|
+| **Event** | A single JSON object delivered over one HTTP PUT (or one serial write). |
+| **Sector** | A timing checkpoint within a lap. Sector 1 starts at the lap loop and ends at the first inner gate. |
+| **Lap end** | The crossing of the lap loop, completing a lap. Treated as a special sector. |
+| **RaceSector** | Cumulative sector index since race start, encoded as `lap × 100 + timingSystemIndex`. The `100` is a fixed multiplier (assumes `splitsPerLap ≤ 100`); the index portion is the raw 0-based `timingSystemIndex` (Goal = 0), not the 1-based `sectorIndex` field. Used to rank pilots — higher means further along the course. |
+| **PositionSnapshot** | The full leaderboard at the moment of a single detection, pre-computed by the sender. |
+| **Stage** | A grouping of rounds (e.g. Qualifying, Final). A round may or may not belong to a stage. |
+| **Heartbeat** | The repeated Hello PUT during startup until the Extension acks. |
+| **Immediate ack** | The receiver's obligation to send 200 OK before processing the body. |

--- a/documentation/POST_Extension_INTERFACE.ja.md
+++ b/documentation/POST_Extension_INTERFACE.ja.md
@@ -1,0 +1,779 @@
+# GATE / LED POST notifications Extension インターフェース仕様書（日本語）
+
+バージョン: 1.1  
+方向: FPVTrackside（送信側）→ Extension（受信側）、一方向  
+対象読者: Extension またはテストクライアントを実装する開発者
+
+本書は単独で完結します。この1ファイルだけを参照して動作するテストクライアントを実装できます。
+
+---
+
+## 1. Extension有効条件と後方互換性
+
+本仕様書に記載された通信は、FPVTrackside の **`ExtensionMode` 設定が `true`** のときに**のみ**発生します。設定は *Application Profile Settings* の **「Gate / LED POST notifications」** カテゴリにあり、デフォルトは `false`、変更後は再起動が必要です。
+
+`ExtensionMode = false` のとき:
+- 本書に記載された通信は一切発生しません
+- 既存の `GATE / LED POST notifications` の動作（`NotificationEnabled`, `NotificationURL`, `NotificationSerialPort` で制御）は完全に保持されます（既存のバグも含む）
+
+`ExtensionMode = true` のとき:
+- 別コンポーネント `ExtensionNotifier` が起動し、本書のイベントを送出します
+- レガシー `RemoteNotifier` は `NotificationEnabled = true` であっても**抑止されます**。ExtensionMode は既存のデータストリームを置き換えるため、両者が同じ URL/COM ポートに同時送信することはありません。
+
+---
+
+## 2. 通信方式
+
+### 2.1 HTTP
+
+| 項目 | 値 |
+|---|---|
+| メソッド | `PUT` |
+| 宛先 URL | プロファイル設定 `NotificationURL` の値（例: `http://127.0.0.1:8765/`） |
+| ヘッダ | `Content-Type: application/json; charset=utf-8` |
+| ボディ | 1リクエストあたり JSON オブジェクト 1個（§4 のエンベロープ参照） |
+| 接続 | HTTP/1.1 keep-alive（送信側は `HttpClient` を使い回し） |
+| 送信側タイムアウト | 1500 ms — 期限内に応答が無いとリクエスト破棄 |
+| 並行性 | セッション中は同時1リクエストのみ（単一ワーカーキューで順序保証） |
+
+### 2.2 Serial（オプション）
+
+| 項目 | 値 |
+|---|---|
+| 宛先 | プロファイル設定 `NotificationSerialPort` のCOMポート名 |
+| ボーレート | 115200 |
+| フレーミング | なし（イベント毎に `serialPort.Write(bytes)` を1回。bytes は UTF-8 化した JSON） |
+| 方向 | **書き込みのみ** — 送信側は読まない |
+| WriteTimeout | 100 ms |
+| 動作 | fire-and-forget。失敗はログのみ |
+| Hello | **シリアルへは送らない** — Hello は HTTP 限定 |
+
+シリアルストリームでイベント区切りが必要な場合、受信側は JSON オブジェクトの境界（`{` と `}` を文字列リテラル考慮の上でカウント）で判定する必要があります。
+
+### 2.3 即時応答ルール — 最重要
+
+Extension は受信ボディの**処理を始める前に**必ず `200 OK` を返さなければなりません。推奨ハンドラ形:
+
+```
+PUT 受信時:
+    body = リクエストボディ読取り        # 高速
+    enqueue(body)                       # メモリ内キュー（非ブロッキング）
+    200 OK 返却（空ボディ）              # ← TTS/LED/ファイルシステムアクセス等よりも前に返す
+```
+
+理由: FPVTrackside の送信キューはイベントを順序通りに直列送信します。応答が遅れると後続イベントすべてが最大 1500 ms ずつ遅延し、負荷時（複数パイロット × 複数セクター/秒）には数秒の遅延に発展します。
+
+Extension が**やってはいけない**こと:
+- 応答前にボディを検証する（検証は応答後）
+- 応答前にダウンストリーム（TTS エンジン、LED COM、ファイル I/O、ネットワーク）を待つ
+- 非空のレスポンスボディを返す（送信側は無視するが時間の無駄）
+
+推奨アーキテクチャ: HTTP サーバスレッドはエンキューのみ、別ワーカースレッドが順次処理。
+
+---
+
+## 3. Hello ハンドシェイク
+
+### 3.1 目的
+
+1. Extension に FPVTrackside 起動を通知する
+2. FPVTrackside のファイルシステムパスを伝達し、後続イベント中の相対パス（`photoPath` 等）を解決可能にする
+3. **Extension が FPVTrackside より先に起動**してもよい設計（Extension は最初の Hello が来るまで待機）
+
+Hello は受信側を「ただのログ吸い込み口」から **FPVTrackside と対等な peer（協調ノード）** に格上げする役割を持ちます。最初の非 Hello イベントが届く時点で Extension は、パイロットメディアの所在（`paths.pilotsDirectory`、`paths.workingDirectory`）、FPVTrackside の表示精度（`decimalPlaces`）、1 ラップのセクター数とどのゲートがラップループか（`timingSystem.splitsPerLap`、各システムの `index`/`role`/`type`）、ホールショット判定や重複ラップ排除に FPVTrackside が使っている閾値（`eventSettings`）をすべて把握済みです。汎用 LED/TTS/スコアボード受信機は、Hello を受けた時点でセクター描画の自動構成、操作者画面と末桁まで一致するラップタイム表示、FPVTrackside と同等のフィルタ判断を行えます — 旧 `RemoteNotifier` の生検出ストリーム単独では達成できなかった機能群です。
+
+### 3.2 FPVTrackside 側の動作
+
+- `ExtensionNotifier` 起動と同時に Hello PUT を即時送信（`t = 0`）
+- `2xx` 応答が無い場合、**2000 ms 間隔**で再送
+- 最初に `2xx` 応答を受信した時点で**そのセッション中はハートビート完全停止** — FPVTrackside を再起動するまで以後 Hello は送信しない
+- Hello は専用の `HttpClient` 呼び出しで送信し、**通常イベントのワーカーキューを経由しない**。通常イベントのスループットには影響しない
+- ハートビート中の接続失敗（TCP 拒否、DNS エラー、タイムアウト）はログを出さない（ノイズ抑止）。成功時のみ1回ログ出力
+
+### 3.3 Extension 側に期待される動作
+
+1. Hello 受信時、ただちに `200 OK` を返却
+2. `config.json` の `fpvt` ブロックを受信内容で**上書き**（§3.5）
+3. 後続イベント処理より前に新パスを Extension 内に反映
+4. Hello はレース情報を含まないため、レース状態の変化を起こしてはいけない
+
+### 3.4 Hello のペイロード
+
+```json
+{
+  "type": "Hello",
+  "ts": "2026-05-03T12:34:56.789Z",
+  "seq": 1,
+  "fpvtVersion": "1.x.x",
+  "platform": "Windows",
+  "paths": {
+    "workingDirectory": "C:\\path\\to\\fpvt\\",
+    "baseDirectory":    "C:\\path\\to\\fpvt\\bin\\",
+    "eventsDirectory":  "C:\\path\\to\\fpvt\\events\\",
+    "profileDirectory": "C:\\path\\to\\fpvt\\data\\default\\",
+    "pilotsDirectory":  "C:\\path\\to\\fpvt\\pilots\\"
+  },
+  "profile": {
+    "name": "default"
+  },
+  "decimalPlaces": 2,
+  "timingSystem": {
+    "count": 4,
+    "primeCount": 1,
+    "splitCount": 3,
+    "splitsPerLap": 4,
+    "allDummy": false,
+    "systems": [
+      { "index": 0, "type": "LapRFTimingSystem", "role": "Prime" },
+      { "index": 1, "type": "LapRFTimingSystem", "role": "Split" },
+      { "index": 2, "type": "LapRFTimingSystem", "role": "Split" },
+      { "index": 3, "type": "LapRFTimingSystem", "role": "Split" }
+    ]
+  },
+  "eventSettings": {
+    "raceStartIgnoreDetections": 0.5,
+    "minLapTime": 5.0,
+    "primaryTimingSystemLocation": "EndOfLap"
+  },
+  "channelSettings": {
+    "channels": [
+      { "band": "Raceband", "number": 1, "frequency": 5658, "colorR": 255, "colorG": 0, "colorB": 0 },
+      { "band": "Raceband", "number": 2, "frequency": 5695, "colorR": 0, "colorG": 255, "colorB": 0 }
+    ]
+  }
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `type` | string | 常に `"Hello"` |
+| `ts` | string | ISO-8601 UTC、ミリ秒精度 |
+| `seq` | int64 | 単調増加カウンタ（§5） |
+| `FpvtVersion` | string | FPVTrackside バージョン |
+| `Platform` | string | `"Windows"` / `"macOS"` / `"Linux"` |
+| `Paths.WorkingDirectory` | string（絶対パス） | `Directory.GetCurrentDirectory()`。**後続イベント中のすべての相対パス（特に `photoPath`）の解決基準** |
+| `Paths.BaseDirectory` | string（絶対パス） | `AppDomain.CurrentDomain.BaseDirectory`。FPVTrackside 実行ファイルの所在 |
+| `Paths.EventsDirectory` | string（絶対パス） | 設定 `EventStorageLocation` から解決。相対設定の場合は `WorkingDirectory` 基準で解決 |
+| `Paths.ProfileDirectory` | string（絶対パス） | プロファイル別データ: `<WorkingDirectory>/data/<profileName>/`。`ProfileSettings.xml` 等を含む |
+| `Paths.PilotsDirectory` | string（絶対パス） | `<WorkingDirectory>/pilots/`。パイロットメディア（写真・動画） |
+| `Profile.Name` | string | アクティブプロファイル名。FPVTrackside セッション中は不変 |
+| `decimalPlaces` | int | `ApplicationProfileSettings.ShownDecimalPlaces`。Extension が時間（ラップタイム・セクタータイム）をテキスト表示する際の推奨小数桁数。Extension はオーバーライドしてもよいが、FPVTrackside の表示と揃えるため既定値はこれに合わせること |
+| `TimingSystem.Count` | int | **設定済み**タイミングシステムの総数（Prime + Split）。接続状態に非依存 |
+| `TimingSystem.PrimeCount` | int | 「Prime」システム数（ラップループ検出）。通常 1 |
+| `TimingSystem.SplitCount` | int | 「Split」システム数（中間セクター検出） |
+| `TimingSystem.SplitsPerLap` | int | **ラップあたりのセクター数。** `SplitCount + 1` に等しい。「+1」は Prime での lap-end 検出（これ自体がラップ最終セクター）の分 |
+| `TimingSystem.AllDummy` | bool | 設定済みシステムがすべてダミー/シミュレータの場合 true。設定タイプから判定し、接続状態には依存しない |
+| `TimingSystem.Systems[]` | array | システム別リスト。**インデックス番号は `DetectionExt.TimingSystemIndex` と完全に一致**: index `0` が Prime（ラップループ）、index `1..splitCount` が Split（中間セクター）でセクター通過順に並ぶ。配列は `index` 昇順。各要素: `index`（0 始まり）、`type`（C# クラス名、例: `"LapRFTimingSystem"`, `"DummyTimingSystem"`）、`Role`（`"Split"` / `"Prime"`）。受信側は `systems[detection.timingSystemIndex]` で直接ゲートのロールを参照できる |
+| `EventSettings.RaceStartIgnoreDetections` | number（秒） | Event 設定「Race Start Ignore Detections」。`RaceStart.ActualStart` から本秒数以内の検出は FPVTrackside 側で破棄される。Extension はレース序盤の「整定中」表示に利用可能 |
+| `EventSettings.MinLapTime` | number（秒） | Event 設定「Smart Minimum Lap Time」。本値より速いラップタイムは重複検出として FPVTrackside 側で破棄される |
+| `EventSettings.PrimaryTimingSystemLocation` | string | Event 設定「Primary Timing System Location」。`"Holeshot"` または `"EndOfLap"` のいずれか。`Holeshot` = ラップループがスタート位置にあるため、最初の lap-end 通過はホールショット（lap 0 → lap 1 への遷移であって実ラップではない）。`EndOfLap` = ラップループがスタート位置の先にあるため、最初の lap-end 通過がそのまま lap 1 終了（ホールショットは存在しない）。Extension はこの値でホールショット検出を表示／抑制するかを判断する |
+| `ChannelSettings.Channels[]` | ChannelInfo[] | イベントで定義されたチャンネル一覧（"Channel Settings"）。各要素は §6.1 の `ChannelInfo`。`colorR/G/B` はイベント設定で割り当てられた表示色。受信側はパイロット未割当時のチャンネル表示やレース外のチャンネル一覧表示に利用可能 |
+
+`TimingSystem` ブロックは FPVTrackside が Hello 送信時点で認識している**設定済みトポロジ**です。接続状態は意図的に含めていません — FPVTrackside 起動直後はほとんどのシステムが接続交渉中で、この時点での connected/disconnected フラグは誤解を招くためです。Extension は `count`, `SplitsPerLap`, 各 `index`/`Role`/`type` をルーティングに利用できます。
+
+すべてのパスは絶対パスで完全に解決済み（`..` 等を含まない）、ホスト OS のパス区切り文字を使用（Windows ではバックスラッシュ、それ以外ではスラッシュ）。実行中の FPVTrackside インスタンスが実際に使用している場所を必ず指します。
+
+### 3.5 Extension の `config.json` スキーマ
+
+Extension は接続状態を永続化することで、FPVTrackside オフライン時でも履歴データへのアクセスを可能にします。
+
+```json
+{
+  "fpvt": {
+    "lastHelloAt": "2026-05-03T12:34:56.789Z",
+    "fpvtVersion": "1.x.x",
+    "platform": "Windows",
+    "paths": {
+      "workingDirectory": "...",
+      "baseDirectory":    "...",
+      "eventsDirectory":  "...",
+      "profileDirectory": "...",
+      "pilotsDirectory":  "..."
+    },
+    "profile": { "name": "default" },
+    "decimalPlaces": 2,
+    "timingSystem": { "...": "§3.4 参照" }
+  },
+  "extension": {
+    "ledComPort": "COM5",
+    "ttsEngine": "...",
+    "...": "..."
+  }
+}
+```
+
+ルール:
+- Hello 受信時は **`fpvt` ブロック全体を上書き** — フィールド単位のマージ禁止（パス構成がセッション間で変わる可能性があるため）
+- `Extension` ブロック（およびその他のトップレベルキー）は Hello 更新時も**保持**しなければならない
+- アトミック書き込み（一時ファイルに書いてリネーム）でクラッシュ耐性を確保
+- 初回 Hello 時に `config.json` が存在しなければ新規作成
+
+### 3.6 パス解決例
+
+後続イベント中のパイロット情報に以下が含まれる場合:
+```json
+"photoPath": "pilots/jdoe/jdoe.mp4"
+```
+Extension は次のように解決:
+```
+absolutePath = path.join(config.Fpvt.Paths.WorkingDirectory, pilot.PhotoPath)
+             = "C:\path\to\fpvt\pilots\jdoe\jdoe.mp4"   （Windows の場合）
+```
+
+`photoPath` が空または null の場合、そのパイロットにメディアは無く、解決を試みてはならない。
+
+---
+
+## 4. 共通エンベロープ
+
+すべてのイベント（Hello を含む）はこのトップレベル形式を持つ:
+
+```json
+{
+  "type": "<イベント名>",
+  "ts": "<ISO-8601 UTC, ms精度>",
+  "seq": <int64>,
+  "...": "Type 固有フィールド"
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `type` | string | イベント識別子. ハンドラ振り分けには本フィールドのみを使うこと |
+| `ts` | string | 送信側がイベント生成時刻を UTC で記録（送信時刻ではない）. ISO-8601 ミリ秒精度、`Z` サフィックス |
+| `seq` | int64 | §5 参照 |
+
+`type` 固有フィールドは `type`/`ts`/`seq` と**同階層**（ラッパでネストしない）.
+
+---
+
+## 5. シーケンス番号と順序保証
+
+- `seq` は送信側が割り当てる単調増加 64bit 整数
+- FPVTrackside 起動時に 1 から開始、Hello を含む全イベントで（atomic に）インクリメント
+- 1 つの FPVTrackside セッション内では `seq` は減少も重複もしない
+- FPVTrackside 再起動を跨ぐと `seq` は 1 にリセット. Extension は `seq` 逆行（または新たな Hello 到来）で再起動を検知可能
+- 送信側はイベントを**順序通り**に配送する（トランスポート毎に単一ワーカーキュー）. 順序が処理に重要なら Extension 側のキューも順序を保つこと
+- Extension は `seq` で欠落・重複検出やミスオーダーロギングに利用してよい
+
+---
+
+## 6. 共通サブオブジェクト
+
+複数イベント間で共有される構造体。
+
+### 6.1 `ChannelInfo`
+
+```json
+{
+  "band": "E",
+  "number": 1,
+  "frequency": 5705,
+  "colorR": 255,
+  "colorG": 64,
+  "colorB": 64
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `band` | string | C# `Band` enum の値名（生）。次のいずれか: `Fatshark`, `Raceband`, `A`, `B`, `E`, `DJIFPVHD`, `SharkByte`（`HDZero` の別名、enum 値同一）, `LowBand`, `Diatone`, `DJIO3`, `DJIO4`, `WalkSnail`、未割当チャンネルは `None`。FPVTrackside のバージョンアップで新しいバンドが追加される可能性があるため、**受信側は値を不透明な文字列として扱い、上記リストが閉じていると仮定してはならない**。 |
+| `number` | int | 通常 1〜8 |
+| `frequency` | int | MHz |
+| `ColorR/G/B` | int (0〜255) | このレースで本チャンネルに割り当てられた表示色 |
+
+### 6.2 `PilotInfoExt`
+
+パイロット情報の標準形. `RaceLoaded`, `NextRace`, `RaceResult`, `PilotRaceState`, `PilotCrashedOut` で使用.
+
+```json
+{
+  "name": "John Doe",
+  "phonetic": "jon doh",
+  "discordID": "jdoe#1234",
+  "photoPath": "pilots/jdoe/jdoe.mp4",
+  "videoFlipped": false,
+  "videoMirrored": false,
+  "channel": { "...": "ChannelInfo, §6.1 参照" }
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `name` | string | パイロット表示名 |
+| `phonetic` | string | TTS 発音ヒント. 明示設定が無い場合は `name` から自動生成 |
+| `discordID` | string \| null | 任意 |
+| `photoPath` | string \| null | `Paths.WorkingDirectory` 基準の**相対パス**. フィールド名は "Photo" だが動画ファイル（`.mp4` 等）も格納される. 空の可能性あり |
+| `VideoFlipped` | bool | 上下反転で表示 |
+| `VideoMirrored` | bool | 左右反転で表示 |
+| `channel` | ChannelInfo | 本レースで本パイロットに割当てられたチャンネル |
+
+### 6.3 `PositionEntry`
+
+順位スナップショットの 1 行（§7.4）.
+
+```json
+{
+  "pilotName": "John Doe",
+  "position": 1,
+  "raceSector": 14,
+  "lastDetectionTime": 23.456
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `pilotName` | string | 表示名で識別 |
+| `Position` | int | 1 始まり. 同着があれば同位を共有（§7.4） |
+| `RaceSector` | int | 到達済み累積セクター index. エンコーディングは `lap × 100 + timingSystemIndex`（§7.4 と用語集を参照）. 値が大きいほど先 |
+| `lastDetectionTime` | number（秒） | 順位算定に使用した最後の検出のレース開始からの秒数. 未検出なら `0` |
+
+### 6.4 `StageInfo`
+
+```json
+{
+  "name": "Qualifying",
+  "stageType": "Default"
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `name` | string | ステージ表示名 |
+| `StageType` | string | `Default`, `DoubleElimination`, `Final`, `StreetLeague`, `ChaseTheAce`（enum 名） |
+
+現レースのラウンドにステージが無ければ `null`.
+
+### 6.5 `SectorInfo`
+
+```json
+{
+  "number": 1,
+  "length": 0.0,
+  "calculateSpeed": false
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `number` | int | コース上のセクター番号（1 始まり） |
+| `length` | number | セクター長（メートル）. 不明なら 0 |
+| `calculateSpeed` | bool | このセクターで速度を計算するか |
+
+ラップ終端「セクター」は暗黙的（ラップループの最終検出に対応）.
+
+### 6.6 `PilotResultEntry`
+
+`RaceResult.Pilots[]` で使用.
+
+```json
+{
+  "pilot": { "...": "PilotInfoExt, §6.2 参照" },
+  "position": 1,
+  "totalLaps": 5,
+  "totalTime": 123.456,
+  "bestLap": 22.345,
+  "bestConsecutive": { "laps": 3, "time": 67.890 },
+  "dnf": false
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `pilot` | PilotInfoExt | メディアパスを含む完全なパイロット情報 |
+| `Position` | int | 本レースの最終順位（1 始まり） |
+| `totalLaps` | int | 完了した有効ラップ数 |
+| `totalTime` | number（秒） | 使用した総レース時間（完走時の終了時刻、または DNF ならレース全長） |
+| `bestLap` | number（秒） \| null | 単独ベストラップ |
+| `bestConsecutive` | object \| null | 連続ベスト（`laps` はイベント設定の連続数、通常 3）. 該当無しなら null |
+| `dnf` | bool | DNF（未完走） |
+
+### 6.7 `StageRankingEntry`
+
+`StageRanking.Ranking[]` で使用.
+
+```json
+{
+  "pilot": { "...": "PilotInfoExt" },
+  "position": 1,
+  "points": 12,
+  "bestLap": 22.345,
+  "bestConsecutive": { "laps": 3, "time": 67.890 }
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `pilot` | PilotInfoExt | |
+| `position` | int | ステージ内順位（1 始まり） |
+| `points` | int \| null | ポイント制イベントの累積ポイント. それ以外なら null |
+| `bestLap` | number（秒） \| null | ステージ内ベストラップ |
+| `bestConsecutive` | object \| null | ステージ内ベスト連続ラップ |
+
+---
+
+## 7. イベント type 一覧
+
+`Hello`（§3）以外の、Extension が受信し得るすべての `type` 値。
+
+### 7.1 `RaceLoaded`
+
+カレントレースが切り替わったとき発火（マネージャに新レースがロードされたとき）. `RacePreStart` より前に到着.
+
+**`RaceManager.ResetRace` 直後にも再発火する** — リセット対象レースを引数として、同じレースを再選択した場合でも `RaceLoaded` を再送する。結果クリアに伴い受信側のパイロット辞書や派生状態が古くなり得るため、`RaceResult.pilots=[]` の「結果無効化」シグナルと対になり、フル状態を再供給する役割を持つ。受信側は冪等な状態置き換えとして扱うこと（同じ `round`/`race` の連続受信を異常と見なさない）。
+
+```json
+{
+  "type": "RaceLoaded",
+  "ts": "...",
+  "seq": 42,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "scheduledStart": "2026-05-03T13:00:00.000Z",
+  "targetLaps": 5,
+  "raceLength": 120.0,
+  "stage": { "...": "StageInfo または null" },
+  "sectors": [ { "...": "SectorInfo" }, ... ],
+  "pilots": [ { "...": "PilotInfoExt" }, ... ]
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `round` | int | ラウンド番号 |
+| `race` | int | ラウンド内のレース番号 |
+| `raceType` | string | `Race` / `TimeTrial` / `AggregateLaps` / `Game` 等（enum 名） |
+| `rcheduledStart` | string (ISO-8601 UTC) \| null | 設定済みなら予定開始時刻. Extension はプリレースカウントダウン用に使用 |
+| `rargetLaps` | int | 設定ラップ数（時間制のみなら 0） |
+| `raceLength` | number（秒） | 設定レース時間（ラップ制のみなら 0） |
+| `stage` | StageInfo \| null | ラウンドのステージ |
+| `sectors` | SectorInfo[] | コースのセクター構成. ラップ終端「セクター」は暗黙のためここに含めない |
+| `pilots` | PilotInfoExt[] | レースに割当てられた全パイロットとチャンネル |
+
+### 7.2 `NextRace`
+
+カレントレース変更時、**次の**レース情報を提供. 次レースのパイロット紹介に使用.
+
+```json
+{
+  "type": "NextRace",
+  "ts": "...",
+  "seq": 43,
+  "round": 3,
+  "race": 3,
+  "raceType": "Race",
+  "scheduledStart": "2026-05-03T13:05:00.000Z",
+  "pilots": [ { "...": "PilotInfoExt" }, ... ]
+}
+```
+
+次レースが無い場合、`Round`/`Race` は `null`、`pilots` は `[]` で送信.
+
+### 7.3 `RacePreStart` / `RaceStart` / `RaceEnd` / `RaceCancelled` / `RaceTimesUp`
+
+ライフサイクルイベント. 共通ボディ.
+
+```json
+{
+  "type": "RacePreStart",
+  "ts": "...",
+  "seq": 44,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "scheduledStart": "2026-05-03T13:00:05.000Z",
+  "actualStart": "2026-05-03T13:00:07.345Z"
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `round` | int | |
+| `race` | int | |
+| `raceType` | string | |
+| `rcheduledStart` | string (ISO-8601 UTC) \| null | `RacePreStart` のみ存在. カウントダウン開始時に決定された**開始予定時刻** |
+| `actualStart` | string (ISO-8601 UTC) \| null | `RaceStart` のみ存在. 実際に Go となり時刻が確定した**開始時刻**. レース時刻の `t0` |
+| `failure` | bool | `RaceCancelled` のみ存在. システム異常による中止なら true、操作者による中止なら false |
+
+5 つの `type` 値:
+- `RacePreStart` — レースアーム完了、**ランダム化されたスタート時刻が確定した直後**、カウントダウン開始直前. **`ScheduledStart` を含む**。`RaceManager.OnRaceStartScheduled`（`OnRacePreStart` ではない）から発火されるため、タイムスタンプは**ランダム化後の真の予定時刻**であり最遅推定値ではない
+- `RaceStart` — カウントダウン終了、レースタイマー開始. **`actualStart` を含む**
+- `RaceTimesUp` — レース時間経過（必ずしもレース終了ではない. 進行中ラップは継続）
+- `RaceEnd` — レース終了（全パイロット終了または停止）
+- `RaceCancelled` — レース中止
+
+`RacePreStart.scheduledStart` は `StartRaceInLessThan(MinStartDelay, MaxStartDelay)` が選んだ**正確な予定スタート瞬間** — `[Now + MinStartDelay, Now + MaxStartDelay]` の一様分布乱数で決定されます。本値は wait ループ実行前に配信されるため、受信側はランダム窓全体（およそ `MaxStartDelay − MinStartDelay` から通信遅延数 ms を引いた時間）をスタート合図準備に使えます。これは特に**アクセシビリティ**用途で価値があります: 聴覚障害者・難聴者、あるいは環境騒音で「Go」のビープ音がマスクされる場面でも、`scheduledStart` に固定された LED パネル／ストロボに頼ることで、他のパイロットと同条件で同じスタート合図を受け取れます — イベントがランダムスタート遅延（`MinStartDelay != MaxStartDelay`）を使う場合でも有効です。`scheduledStart`（`RacePreStart`）と `actualStart`（`RaceStart`）を突き合わせれば、運営側はスタートタイミングのジッタを事後監査することも可能です.
+
+### 7.4 `DetectionExt`
+
+最も高頻度なイベント. ゲート検出（セクター通過またはラップ終端）毎に 1 回発火. Extension 用途では既存の `DetectionDetails` を置き換え. レガシー Notifier も有効な場合、両方が wire 上に流れる.
+
+レガシー `DetectionDetails` と比較すると、`DetectionExt` は受信側で従来導出する必要があった情報を**事前計算済みで配信**します:
+
+- **`sectorTime`** — 本検出で終了したセクターの所要時間。レガシーは累積 `Time` のみで、受信側は各パイロットの前回検出を記憶し差分計算する必要があった（途中でイベント欠落があれば破綻）
+- **`positionSnapshot[]`** — その瞬間の全パイロット順位（検出対象だけでなく全員）を `Race.GetTrackPosition` 済みの順序で同梱。レガシーは検出パイロット自身の `Position` のみ
+- **`raceFinishedForPilot`**, **`valid`**, **`lapTimeSoFar`**, **`raceSector`** — 完走フラグ・フィルタ有効フラグ・進行中ラップタイム・累積順位キー
+- **`round` / `race` / `raceType`** — 各検出がレース識別子を持つため、直近の `RaceState` と相関を取る必要がなくなる
+
+**重複排除**: 送信側は detection ID でフィルタするため、同じ検出について本イベントが重複送信されることはない（FPVTrackside 内部で `OnSplitDetection` と `OnLapDetected` の両方が同一検出に対し発火するケースがあっても）。レガシー `RemoteNotifier` には重複排除が**無く**、ラップループ通過のたびに同じ検出が 2 回配信されていました — 受信側でのフィルタリングが必須でした.
+
+```json
+{
+  "type": "DetectionExt",
+  "ts": "...",
+  "seq": 99,
+  "detectionId": "1f8a2c3d-...",
+  "round": 3,
+  "race": 2,
+  "pilotName": "John Doe",
+  "channel": { "...": "ChannelInfo" },
+  "timingSystemIndex": 0,
+  "isLapEnd": false,
+  "lapNumber": 2,
+  "sectorIndex": 1,
+  "raceSector": 7,
+  "raceTime": 38.421,
+  "sectorTime": 5.123,
+  "lapTimeSoFar": 18.234,
+  "position": 2,
+  "valid": true,
+  "positionSnapshot": [ { "...": "PositionEntry" }, ... ],
+  "raceFinishedForPilot": false
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `detectionId` | string (GUID) | 一意 ID. 重複排除に利用可 |
+| `Round`, `Race` | int | レース識別 |
+| `pilotName` | string | |
+| `channel` | ChannelInfo | |
+| `timingSystemIndex` | int | 検出元タイミングシステムの index（0 始まり）. 物理ゲートに対応 |
+| `isLapEnd` | bool | ラップループ通過なら true、中間セクターなら false |
+| `lapNumber` | int | 進行中（`IsLapEnd=true` なら完了直後）のラップ番号（0 始まり） |
+| `SectorIndex` | int | ラップ内セクター index（1 始まり）。実装は `(timingSystemIndex % splitsPerLap) + 1`（内部セクター未設定時は `Max(1, timingSystemIndex + 1)`）。Prime/ラップループは `timingSystemIndex=0` なので**ここでの値は `1`** になる。すなわち、ラップエンド通過は「直前ラップの最終セクター」ではなく「次ラップの S1」として番号付けされる。"end-of-lap" セクターのラベルが必要な受信側は本フィールドではなく `splitsPerLap` と `isLapEnd` から導出すること |
+| `raceSector` | int | レース開始からの累積セクター index. エンコーディングは `lap × 100 + timingSystemIndex`. `100` は固定の乗数（`splitsPerLap` ではない）であり、インデックス部分は 0 始まりの生 `timingSystemIndex`（Goal = 0）で、上の 1 始まり `sectorIndex` フィールドとは別物. 順序を曖昧なくするためには `splitsPerLap ≤ 100` を前提とする. 順位算定の内部値 — `PositionEntry.RaceSector` と同じ |
+| `raceTime` | number（秒） | `RaceStart.ActualStart` からの本検出までの秒数 |
+| `sectorTime` | number（秒） \| null | 本検出で終了したセクターの所要時間. 当該パイロットの本ラップ内に先行検出が無ければ null（例: ホールショット） |
+| `lapTimeSoFar` | number（秒） | 現ラップ経過時間（`isLapEnd` なら最終ラップタイム） |
+| `position` | int | 本検出時点での当該パイロットの順位 |
+| `valid` | bool | タイミングシステムやルールでフィルタされた検出は false（可視性のため送信は継続） |
+| `PositionSnapshot` | PositionEntry[] | 本検出時点での**全パイロット**の順位スナップショット. 送信側で `Race.GetTrackPosition()` から事前計算済み（セクター進捗を考慮 — ラップ深部にいるパイロットが上位）. Extension 側で**再計算不要**. 長さ = レース内パイロット数 |
+| `raceFinishedForPilot` | bool | 本検出が当該パイロットの本レース最終検出（目標ラップ到達等）なら true |
+
+**Position の意味**（`Race.GetTrackPosition` に一致）:
+- `raceSector` 降順が第1キー（コース上で先にいる方が上）、検出時刻の昇順が第2キー（同セクターなら早い検出が上）
+- 同着（同セクター・同時刻）は同位を共有. 下位パイロットの `Position` 値が複製される. 受信側は `Position == 1` の要素が複数ある可能性を許容すること
+
+### 7.5 `RaceResult`
+
+`ResultManager` がレースの結果状態変化を通知した時に発火。発火コンテキストは 2 種類:
+
+1. **レース終了時の結果確定** — **`RaceEnd` の直前**に送信される（後ではない）。典型的な終了シーケンスは `RaceResult` → `StageRanking`（ステージ所属時のみ） → `RaceEnd`。受信側は `RaceResult` 受信時点でレース終了処理を進めてよく、`RaceEnd` を待つ必要はない
+2. **結果クリア** — レースの保存結果がクリアされた時に発火。`RaceManager.ResetRace`（操作者によるリセット）に加え、FPVTrackside 起動時に過去走行済みレースを再ロードした際にも自動的に発火する。このときの `pilots` は **空配列（`[]`）** になり、本イベントは事実上「結果無効化」シグナルとして機能する
+
+```json
+{
+  "type": "RaceResult",
+  "ts": "...",
+  "seq": 150,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "pilots": [ { "...": "PilotResultEntry" }, ... ]
+}
+```
+
+`pilots` は `Position` 昇順、DNF は末尾。**結果クリア時は `pilots` が `[]` になる** — 結果 UI を描画する受信側は、空リストを「0 名が完走した」ではなく「表示をクリアせよ」と解釈すること。
+
+### 7.6 `StageRanking`
+
+ステージ順位変動時（`ResultManager` の結果再計算時）に送信される。 **直前完了レースがステージに属する場合のみ**（`Race.Round.Stage != null`）.
+
+```json
+{
+  "type": "StageRanking",
+  "ts": "...",
+  "seq": 160,
+  "stage": { "...": "StageInfo" },
+  "ranking": [ { "...": "StageRankingEntry" }, ... ]
+}
+```
+
+`Ranking` は `Position` 昇順。`RaceResult`（§7.5）と同様、結果クリア（レースリセット・起動時の再ロード）時にも発火する。その場合 `ranking` は空配列または集計値がゼロ／null のエントリを含むため、「ステージ順位無効化」シグナルとして扱うこと。
+
+### 7.7 `PilotCrashedOut`
+
+パイロットがクラッシュアウトと判定されたとき発火（レースディレクター手動、またはスタティック検出による自動）.
+
+```json
+{
+  "type": "PilotCrashedOut",
+  "ts": "...",
+  "seq": 110,
+  "pilot": { "...": "PilotInfoExt" },
+  "manuallySet": true
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `pilot` | PilotInfoExt | チャンネル・メディアパスを含む |
+| `manuallySet` | bool | true = レースディレクター手動、false = 自動検出 |
+
+### 7.8 `PilotRaceState`
+
+カレントレースのパイロット名簿が変更されたとき発火（後発参加など）.
+
+```json
+{
+  "type": "PilotRaceState",
+  "ts": "...",
+  "seq": 35,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "pilots": [ { "...": "PilotInfoExt" }, ... ]
+}
+```
+
+`pilots` は変更**後の現在の全名簿**（追加/削除されたパイロットのみではない）.
+
+### 7.9 `PilotStaggeredStart`
+
+タイムトライアル系レースで FPVTrackside の "Time Trial Staggered Start" 設定が有効な時のみ発火。`RaceManager.StartStaggered` が各パイロットを順次スタートさせる際、**そのパイロットの go 合図が出る瞬間**に 1 件ずつ送信。
+
+```json
+{
+  "type": "PilotStaggeredStart",
+  "ts": "...",
+  "seq": 47,
+  "round": 1,
+  "race": 3,
+  "pilot": { "...": "PilotInfoExt (§6.2)" },
+  "orderIndex": 0,
+  "totalPilots": 4,
+  "delaySeconds": 3.0
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `round` / `race` | int | 対象レースの識別子 |
+| `pilot` | PilotInfoExt | スタートするパイロット。`channel.colorR/G/B` をそのまま LED 等の物理出力に流せる |
+| `orderIndex` | int | スタート順の 0 始まりインデックス。`0` が最初に go するパイロット |
+| `totalPilots` | int | 本レースで staggered スタートする総人数 |
+| `delaySeconds` | number（秒） | パイロット間のスタート間隔。`RaceStart.actualStart + (orderIndex+1) * delaySeconds` がそのパイロットの go タイミング |
+
+**スタート順序**: イベント内ベストタイム順位（`LapRecordManager.GetTimePosition`）昇順 → 同順位は周波数昇順。初回ヒート等で PB が無いパイロットは全員同順位扱いとなり、周波数順にスタートする。
+
+**他のスタートモードでは発火しない**:
+- 同時スタート（通常 Race）→ `RaceStart` 1 件で完結
+- 遅延スタート（`MinStartDelay`/`MaxStartDelay`）→ `RacePreStart` + `RaceStart` で完結
+
+受信側は本イベントの**到着自体**を staggered start のシグナルとして扱える。Hello に staggered フラグは含まれない。
+
+---
+
+## 8. 時刻と数値の表現
+
+- すべての時刻（`ts`, `ScheduledStart`, `actualStart`）: ISO-8601 UTC、ミリ秒精度、`Z` サフィックス. 例: `2026-05-03T12:34:56.789Z`
+- すべての時間長（`SectorTime`, `lapTimeSoFar`, `RaceTime`, `bestLap`, `BestConsecutive.Time`, `TotalTime`, `RaceLength`）: JSON 数値、**秒**単位、小数可. `TimeSpan` 文字列は使わない
+- すべての順位・カウント: JSON 整数. 注記が無い限り 1 始まり
+- 真偽値: JSON `true` / `false`. `0`/`1` は使わない
+- 文字列は JSON ペイロード中で UTF-8
+
+---
+
+## 9. 障害時の挙動
+
+- 送信側は HTTP 失敗時にイベントを再送しない. タイムアウト・接続エラー・非 2xx 応答はサイレントに破棄（エラー型変化時のみログ）
+- 送信側 HTTP キュー容量は 200 イベント. 満杯時は**新規イベントを破棄**（最古ではない）. Extension が即時 ack + 非同期処理を守る限り発生しない
+- 送信側シリアルキュー容量は 50 イベント、同様の破棄ポリシー
+- Extension からの再送要求は不可. 欠落時の状態回復は次の `RaceLoaded` / `RaceResult` / `StageRanking` で行う
+- Hello は最初の 2xx まで再試行. 以降はセッション中再送なし
+
+---
+
+## 10. 受信側要件サマリ
+
+Extension（あなたの作る外部アプリケーション） は**必ず**以下を満たすこと:
+
+1. FPVTrackside の `NotificationURL` 設定の URL で HTTP `PUT` を待機
+2. リクエストボディ処理の**前に** `200 OK`（空ボディ）を返却
+3. JSON をパースし `type` フィールドで振り分け
+4. **未知の `type` 値はサイレントに無視**（200 OK は通常通り返却）. 将来未知の`type`が追加されることへの対策
+5. `Hello` 受信時: `paths` と `Profile`（および `decimalPlaces` と `TimingSystem`）を `config.json` の `fpvt` ブロックにアトミックに永続化
+6. `photoPath` 等の相対パスは `config.fpvt.paths.workingDirectory` を基準に解決
+7. `seq` リセットを許容（`seq` 減少を送信側再起動と判定し、ログ出力するがクラッシュしない）
+8. `detectionId` 重複を許容（送信側でフィルタ済みだが、防御的に重複排除）
+
+Extension は以下を**推奨**:
+
+- 重い処理（TTS、LED 書き込み、ファイルスキャン）は HTTP ハンドラとは別スレッドで実行
+- 直近 Hello の `paths` をキャッシュし、FPVTrackside オフライン時にも履歴データスキャンを可能に
+- 想定外フィールド・未知 `type` を debug レベルでログ出力
+
+---
+
+## 11. ミニマルテストクライアント（疑似コード）
+
+```
+config = read_or_default("config.json")
+
+server = http.create_server(handle)
+server.listen(config.Extension?.Port ?? 8765)
+
+queue = bounded_queue(1000)
+spawn worker(queue)
+
+def handle(request, response):
+    body = request.read_body_sync()       # 軽量
+    response.send(200)                    # ★ まず ack
+    queue.try_enqueue(body)               # 満杯なら破棄（ログ出力）
+
+def worker(queue):
+    while true:
+        body = queue.dequeue()
+        evt = json.parse(body)
+        match evt.Type:
+            "Hello":
+                config.Fpvt = {
+                  "lastHelloAt":   evt.Ts,
+                  "fpvtVersion":   evt.FpvtVersion,
+                  "platform":      evt.Platform,
+                  "paths":         evt.Paths,
+                  "profile":       evt.Profile,
+                  "decimalPlaces": evt.DecimalPlaces,
+                  "timingSystem":  evt.TimingSystem
+                }
+                write_atomic("config.json", config)
+            "RaceLoaded":   on_race_loaded(evt)
+            "NextRace":     on_next_race(evt)
+            "RacePreStart" | "RaceStart" | "RaceTimesUp" | "RaceEnd" | "RaceCancelled":
+                on_race_lifecycle(evt)
+            "DetectionExt": on_detection(evt)
+            "RaceResult":   on_result(evt)
+            "StageRanking": on_stage_ranking(evt)
+            "PilotCrashedOut": on_crash(evt)
+            "PilotRaceState":  on_roster_change(evt)
+            _: log_debug("ignored Type:", evt.Type)
+```
+
+これだけで全イベント受信、`config.json` 永続化、ハンドラ振り分けが可能です. 各 `on_*` ハンドラ内ではメディアパス解決を `path.join(config.Fpvt.Paths.WorkingDirectory, pilot.PhotoPath)` で行い、必要に応じて LED/TTS を発火します.
+
+---
+
+## 12. 用語集
+
+| 用語 | 意味 |
+|---|---|
+| **イベント** | 1 回の HTTP PUT（または 1 回のシリアル書き込み）で配送される 1 個の JSON オブジェクト |
+| **セクター** | ラップ内のタイミングチェックポイント. セクター 1 はラップループ通過直後から最初の内側ゲートまで |
+| **ラップ終端** | ラップループの通過. ラップを完了させる. 特殊なセクター扱い |
+| **RaceSector** | レース開始からの累積セクター index. エンコーディングは `lap × 100 + timingSystemIndex`. `100` は固定の乗数（`splitsPerLap ≤ 100` を前提）であり、インデックス部分は 0 始まりの生 `timingSystemIndex`（Goal = 0）で、1 始まりの `sectorIndex` フィールドとは別物. 順位算定に使用 — 大きいほどコース上で先 |
+| **PositionSnapshot** | 1 個の検出時点での順位表全体（送信側で事前計算済み） |
+| **Stage** | ラウンドのグルーピング（例: 予選、決勝）. ラウンドはステージに属する場合と属さない場合がある |
+| **Heartbeat** | 起動時、Extension の ack を受けるまで繰り返される Hello PUT |
+| **即時 ack** | 受信側がボディ処理前に 200 OK を返す義務 |


### PR DESCRIPTION
Branch: `POST-Notefication-Extension`
Companion repository: [`zubon2003/FT_extensions`](https://github.com/zubon2003/FT_extensions) — wire-format spec + **proof-of-concept** receivers / LED firmware for verification only (see *Test / demonstration implementations* below).

Adds an opt-in **Extension Mode** that replaces the legacy `RemoteNotifier` with a richer race-event stream over the same HTTP PUT / serial transports already configured for Gate / LED POST notifications. Off by default; existing installations see no behavior change.

## Summary

When `ExtensionMode = true`, a new `ExtensionNotifier` emits race load, sector-aware detections with full position snapshots, race results, stage rankings, pilot media paths, scheduled-start broadcasts, staggered-start signals, and a `Hello` context handshake. The two notifiers are mutually exclusive: enabling Extension Mode suppresses `RemoteNotifier`, so the configured URL / COM port never receives both streams simultaneously.

The full wire format is documented in `FT_extensions/INTERFACE.en.md` — the spec is self-contained, so a test client can be built from that file alone.

## Branch scope (vs upstream `master`)

| File | Change |
|---|---|
| `ExternalData/ExtensionNotifier.cs` | **New file, +1502 lines.** All of the new logic. Subscribes to `RaceManager.OnRaceStartScheduled` so `RacePreStart` carries the post-randomisation planned start moment, and to `RaceManager.OnPilotStartStaggered` for the new `PilotStaggeredStart` event. |
| `UI/ApplicationProfileSettings.cs` | **+5 lines.** Adds `bool ExtensionMode` (default `false`, `[NeedsRestart]`) under the existing *Gate / LED POST notifications* category. No other property altered. |
| `UI/EventLayer.cs` | **±22 lines.** Declares the field, instantiates `ExtensionNotifier` only when `ExtensionMode` is `true`, and disposes it. When `ExtensionMode = true` the legacy `RemoteNotifier` is **suppressed regardless of `NotificationEnabled`** to avoid duplicate traffic on the same URL/COM port. The legacy startup condition is the only line touched. |
| `RaceLib/RaceManager.cs` | **+8 lines.** Adds the `OnPilotStartStaggered` event and fires it once per pilot inside `StartStaggered`'s loop. Used only by `ExtensionNotifier`; no existing call sites are altered. |
| `documentation/POST_Extension_INTERFACE.en.md` | **New file, +779 lines.** Full wire-format specification for the Extension Mode protocol. Vendored in-tree (identical to `FT_extensions/INTERFACE.en.md`) so reviewers can read the contract without cloning a second repository. |
| `documentation/POST_Extension_INTERFACE.ja.md` | **New file, +779 lines.** Japanese translation of the above; identical content. |

`ExternalData/RemoteNotifier.cs` is **not modified** (verified via `git diff`).

Totals: 3 new files (1 source + 2 spec docs) + 35 lines of source wiring across three existing files. **All legacy behavior is preserved when `ExtensionMode = false`** — the default for every existing installation. Reviewers can verify the no-op path is intact by reading the three small source hunks.

## What this enables (vs legacy `Gate / LED POST Notifications`)

Legacy notifications emitted raw detection pulses and a 5-state race lifecycle — without race composition, without filesystem context, and without scheduling info. With `ExtensionMode = true`, `ExtensionNotifier` adds:

### Detection stream upgrades

- **`sectorTime`** — per-sector elapsed time delivered directly. Legacy receivers had to remember each pilot's previous `Time` and compute the delta, with no defense against missed or out-of-order events.
- **`positionSnapshot[]`** — full leaderboard at the moment of each detection, pre-computed by `Race.GetTrackPosition`. Legacy carried only the detected pilot's `Position`; receivers had to maintain their own track-position model.
- **`detectionId`-based deduplication** — FPVTrackside fires both `OnSplitDetection` and `OnLapDetected` for every lap-loop crossing (the prime gate is conceptually both the final split sector and the lap end), so the legacy stream delivered each lap-end **twice** with no way to tell them apart. `ExtensionNotifier` deduplicates against a recent-ID LRU, so receivers see each physical detection exactly once.
- **Per-event race identification** — every event carries `round` / `race` / `raceType`. Legacy detection messages had no race identifier in the payload, forcing receivers to correlate against the most recent `RaceState`.

### `Hello` as a context bootstrap

The `Hello` handshake gives receivers everything needed to operate as a peer of FPVTrackside, not just a passive log sink:

- **Filesystem paths** (`workingDirectory`, `baseDirectory`, `eventsDirectory`, `profileDirectory`, `pilotsDirectory`) — receivers can resolve relative paths like `photoPath: "B.png"` against the same working directory FPVTrackside is using, enabling pilot intro screens with the operator's actual media files.
- **`decimalPlaces`** — receivers render lap/sector times with the same precision as FPVTrackside's on-screen display, keeping LED panels, web overlays, and physical scoreboards consistent with the operator's UI.
- **`timingSystem.splitsPerLap`** plus per-system `index`/`role`/`type` — receivers know how many sectors a lap has, which physical index is the lap-loop, and what hardware is wired to each gate. Generic LED/TTS extensions can auto-configure their sector graphics from the `Hello` payload instead of requiring per-event manual setup.
- **`eventSettings.minLapTime` / `raceStartIgnoreDetections` / `primaryTimingSystemLocation`** — the same thresholds FPVTrackside uses internally for holeshot detection and duplicate-lap filtering, so receivers replicate those decisions exactly instead of diverging.
- **`channelSettings.channels[]`** — the event's defined channels (band, number, frequency, assigned display colour) for un-pilot-bound listings such as spectator OSDs.

The `Hello` block is persisted to `config.json` so historical events remain interpretable when FPVTrackside is offline.

### Scheduled-start awareness

`RacePreStart` is emitted from `RaceManager.OnRaceStartScheduled` (not `OnRacePreStart`), so its `scheduledStart` field is the **post-randomisation** planned start moment — the exact future instant `RaceManager` will hand off to `OnRaceStart`. Concrete consequences:

- **Accessible / fair start cues** — a deaf or hard-of-hearing pilot, or any pilot who can't hear "GO" over ambient noise, can rely on an LED panel or strobe that fires at exactly `scheduledStart`. Every receiver sees the same exact timestamp ahead of time, so cues fire synchronously across all devices — no per-receiver reaction delay, no audio-vs-LED skew. **This works even when the event configures a randomised start delay (`MinStartDelay != MaxStartDelay`).**
- **Pre-countdown animations** — receivers pre-compute countdown graphics (3 / 2 / 1 / GO) anchored to a known future timestamp.

### Staggered Time Trial starts

`PilotStaggeredStart` (spec §7.9) fires once per pilot from inside `RaceManager.StartStaggered`'s loop, the instant that pilot's go signal is given. The payload carries the full `PilotInfoExt` (including `channel.colorR/G/B`), `orderIndex`, `totalPilots`, and `delaySeconds`. Receivers can light the pilot's lane and announce them per pilot. The arrival of this event is itself the staggered-mode signal — no separate `Hello` flag is needed.

### Final results & stage standings, ready to display

Legacy notifications had **no result event** — `RaceState{State:"End"}` was a bare marker with no pilot data. Receivers wanting final positions, best lap, or 3-lap consecutive bests had to either maintain a running tally from every `DetectionDetails` or query FPVTrackside's HTTP/Webb interface separately. Stage-level standings were entirely off the table.

- **`RaceResult`** — fires immediately before `RaceEnd` with a fully ordered `pilots[]` of `PilotResultEntry`: `position`, `totalLaps`, `totalTime`, `bestLap`, `bestConsecutive { laps, time }`, `dnf`, plus the full `PilotInfoExt` (name, channel, photo path). A scoreboard receiver can render the final order without holding any per-detection state.
- **`StageRanking`** — fires when stage results recompute, only when the just-finished race belongs to a stage (`Race.Round.Stage != null`), with `ranking[]` of `StageRankingEntry`: `position`, `points`, `bestLap`, `bestConsecutive`. Tournament progression UIs, bracket displays, and "qualifying leaderboards updated" overlays follow directly.

Both events also fire with empty arrays on result invalidation (`RaceManager.ResetRace`, startup re-load), giving receivers a clean "clear the display" signal the legacy stream never delivered.

## Behavior

### When `ExtensionMode = false` (default)

Identical to current behavior. `ExtensionNotifier` is never instantiated; no new HTTP traffic, no new serial writes, no new event subscriptions, no `Hello` heartbeat. Pre-existing behavior in `RemoteNotifier` (including the duplicate-fire of `OnSplitDetection` + `OnLapDetected` for lap ends) is preserved verbatim.

### When `ExtensionMode = true`

`ExtensionNotifier` starts and the legacy `RemoteNotifier` is suppressed. It:

1. Sends a `Hello` PUT every 2 s on startup until the first 2xx response, delivering FPVTrackside's resolved paths, active profile name, the `decimalPlaces` rendering preference, a `timingSystem` snapshot (count, splits per lap, per-system `index`/`role`/`type`), an `eventSettings` block (`raceStartIgnoreDetections`, `minLapTime`, `primaryTimingSystemLocation`), and a `channelSettings.channels[]` array. The `systems[]` array is indexed identically to `DetectionExt.timingSystemIndex` (index 0 = Prime/lap-loop, 1..splitCount = Splits) so receivers can directly look up the role of a detected gate. Heartbeat-phase connection failures (TCP refused / DNS / timeout) are silently swallowed per spec §3.2 — only the successful handshake is logged.
2. Subscribes to and processes:
   - `RaceManager.OnRaceChanged` → emits `RaceLoaded` + `NextRace`. `NextRace` is computed with `GetNextRace(unfinishedOnly: true, allowCurrent: false)` so it returns the next race in sequence, or the documented `round`/`race=null`, `pilots=[]` end-of-schedule payload — never the just-loaded race.
   - `RaceManager.OnRaceReset` → re-emits `RaceLoaded`. `OnRaceChanged` only fires on a current-race switch and stays silent when the operator re-selects the same race after a reset, so this companion subscription resupplies the full state. Consecutive deliveries of the same `round`/`race` are normal per spec §7.1.
   - `RaceManager.OnRaceStartScheduled` → emits `RacePreStart` carrying the resolved `startTime` (a uniformly distributed pick in `[Now + MinStartDelay, Now + MaxStartDelay]`) as `scheduledStart`. Receivers anchor LED/strobe start cues to this exact future instant.
   - `OnRaceStart` / `OnRaceEnd` / `OnRaceCancelled` / `OnRaceTimesUp` → `RaceStart` / `RaceEnd` / `RaceCancelled` / `RaceTimesUp` lifecycle events.
   - `RaceManager.OnSplitDetection` + `OnLapDetected` → unified `DetectionExt` with per-detection `positionSnapshot` for all pilots, deduplicated by `Detection.ID` to suppress the upstream double-fire.
   - `RaceManager.OnPilotAdded` / `OnPilotRemoved` → `PilotRaceState`.
   - `RaceManager.OnChannelCrashedOut` → `PilotCrashedOut`.
   - `RaceManager.OnPilotStartStaggered` → `PilotStaggeredStart` (spec §7.9).
   - `ResultManager.RaceResultsChanged` → `RaceResult`, plus `StageRanking` when the race belongs to a stage (`Race.Round.Stage != null`).

## Latency / robustness improvements vs. legacy `RemoteNotifier`

The new path is designed for real-time use and fixes several latency bottlenecks in the legacy notifier:

| Aspect | Legacy `RemoteNotifier` | `ExtensionNotifier` |
|---|---|---|
| Worker queues | 1 shared (HTTP + Serial) | 2 separate (`-HTTP`, `-Serial`) |
| HTTP wait | 10 s `WaitOne` per event | 1.5 s `task.Wait` per event, with `HttpClient` keep-alive |
| Serial `WriteTimeout` | 12 s | 100 ms (fire-and-forget, no reads) |
| Detection double-emit | yes (lap-end fires twice) | filtered by `Detection.ID` |
| Queue capacity | unbounded | bounded (HTTP 200, Serial 50) — drops new events when full, logs once |
| Position computation | none in payload | `Race.GetTrackPosition()` snapshot for **all** pilots, sector-aware |
| Sequence numbers | none | monotonic `seq` on every event |
| Result events | none (only `RaceState{State:"End"}` marker) | `RaceResult` + `StageRanking` with full per-pilot data |
| Race composition | none | `RaceLoaded` + `NextRace` with `PilotInfoExt` and `SectorInfo` |
| Scheduled start | none | `RacePreStart.scheduledStart` after randomised delay is resolved |

These changes apply only to `ExtensionNotifier`; the legacy notifier keeps its original behavior.

## Configuration

In *Application Profile Settings* → *Gate / LED POST notifications*:

- **Extension Mode** — new checkbox (off by default). Restart required.
- **Notification URL** — reused (the same URL receives the new event types).
- **Notification Serial Port** — reused. The Extension may set its own, separate COM port for downstream LED control.
- **Notification Enabled** — controls only the legacy `RemoteNotifier`. When *Extension Mode* is on, `RemoteNotifier` is suppressed regardless of this flag (prevents duplicate traffic on the same URL / COM port).

The two notifiers do **not** run in parallel — *Extension Mode* takes precedence and supersedes the legacy stream.

## Receiver requirements (summary)

Documented in detail in `FT_extensions/INTERFACE.en.md` §10. Highlights:

1. Respond `200 OK` **before** processing the body — otherwise sender queue stalls cascade.
2. Tolerate unknown `type` values (forward compatibility).
3. On `Hello`, persist the `fpvt` block to `config.json` atomically; preserve the receiver's own `extension` block across updates.
4. Resolve `photoPath` against `paths.workingDirectory`.
5. Tolerate duplicate `detectionId` (defensive dedup, even though the sender filters).
6. Tolerate `seq` resets as sender-restart signals.

## Test / demonstration implementations

The companion repository [`zubon2003/FT_extensions`](https://github.com/zubon2003/FT_extensions) hosts **proof-of-concept** code whose only purpose is to demonstrate and verify the wire contract. It is **not a production-grade integration**, not an officially endorsed reference, and not intended for deployment as-is.

- **`INTERFACE.en.md` / `INTERFACE.ja.md`** — the wire-format specification (identical to the `documentation/POST_Extension_INTERFACE.{en,ja}.md` files vendored in this PR). **This is the authoritative artifact.**
- **`sample/`** — a Node.js receiver wired to socket.io overlays, VOICEVOX / Google TTS, LED serial output, ATEM camera switching, and F1-style leaderboards. **Demonstration only**: exercises every event type so the spec can be observed end-to-end, but not hardened, not packaged, and not intended as a deployable extension.
- **`test/`** — a single-file minimal receiver (`server.js`) that simply logs every incoming event to the console. **Smoke-test scaffold** for protocol verification.
- **`led/`** — Arduino / ESP32 firmware (LED master + countdown / normal slaves) and Python authoring tools. **Hobbyist proof-of-concept** for hardware integration.

With an FPVTrackside build of this PR and `ExtensionMode = true`, pointing `NotificationURL` at the `sample` or `test` receiver lets reviewers exercise the wire contract end-to-end. These receivers illustrate one possible consumer of the protocol; they do not prescribe a receiver architecture.

## Backward compatibility

Pre-existing installations with `ExtensionMode` absent from `ProfileSettings.xml` read it as `false` on startup (C# `bool` default), producing identical behavior to before.
