### PR TITLE
Add RaceStartAnnouncement event + bound ExtensionNotifier dispose

### DIFF
--- a/ExternalData/ExtensionNotifier.cs
+++ b/ExternalData/ExtensionNotifier.cs
@@ -211,6 +211,17 @@ namespace ExternalData
             UnsubscribeRaceManager();
             UnsubscribeResultManager();
 
+            // Drop queued items before WorkQueue.Dispose() runs — its
+            // thread.Join() would otherwise wait while the worker drains every
+            // pending HTTP PUT at up to 1500 ms apiece. With an unreachable
+            // receiver and a race-end backlog (RaceEnd / RaceResult /
+            // StageRanking / trailing DetectionExt), that freezes "Back to
+            // event selection" for several seconds. Clearing first bounds the
+            // wait to at most one in-flight request. Per spec §9 the sender
+            // does not retry on failure, so dropping the tail is acceptable.
+            try { httpQueue?.Clear(); } catch { }
+            try { serialQueue?.Clear(); } catch { }
+
             try { serialPort?.Close(); } catch { }
             try { serialPort?.Dispose(); } catch { }
             serialPort = null;
@@ -493,6 +504,30 @@ namespace ExternalData
                 next = null;
             }
             Send(BuildNextRace(next));
+        }
+
+        // Fires the instant SoundManager.StartRaceIn() begins speaking the
+        // "Arm your quads…" announcement — i.e. EventLayer.StartRace's
+        // delayedStart branch. Distinct from RacePreStart, which is sent
+        // ~MaxStartDelay seconds later when the speech callback runs
+        // RaceManager.StartRace → StartRaceInLessThan → OnRaceStartScheduled.
+        // Receivers anchor LED/strobe cues at speech-start (well before the
+        // randomised PreRaceStart resolution) by listening for this event.
+        public void EmitRaceStartAnnouncement(TimeSpan delay, Race race)
+        {
+            if (disposed || race == null) return;
+            DateTime nowUtc = DateTime.UtcNow;
+            Send(new RaceStartAnnouncementMessage
+            {
+                Type = "RaceStartAnnouncement",
+                Ts = nowUtc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Seq = NextSeq(),
+                Round = race.RoundNumber,
+                Race = race.RaceNumber,
+                RaceType = race.Type.ToString(),
+                DelaySeconds = delay.TotalSeconds,
+                ExpectedStart = (nowUtc + delay).ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+            });
         }
 
         private void RaceManager_OnRaceStart(Race race)
@@ -1416,6 +1451,18 @@ namespace ExternalData
         public long Seq { get; set; }
         public PilotInfoExt Pilot { get; set; }
         public bool ManuallySet { get; set; }
+    }
+
+    public class RaceStartAnnouncementMessage
+    {
+        public string Type { get; set; }
+        public string Ts { get; set; }
+        public long Seq { get; set; }
+        public int Round { get; set; }
+        public int Race { get; set; }
+        public string RaceType { get; set; }
+        public double DelaySeconds { get; set; }
+        public string ExpectedStart { get; set; }
     }
 
     public class PilotStaggeredStartMessage

--- a/UI/EventLayer.cs
+++ b/UI/EventLayer.cs
@@ -1010,6 +1010,22 @@ namespace UI
                 // Trigger the sound. The actual race start will happen after it ends
                 TimeSpan delay = EventManager.Event.MaxStartDelay;
 
+                // Emit RaceStartAnnouncement at the exact instant the "Arm your
+                // quads…" speech begins. RacePreStart is sent ~delay seconds
+                // later (after the speech callback runs StartRaceInLessThan),
+                // so receivers that need to anchor LED/strobe cues at the start
+                // of the announcement subscribe to this event instead.
+                //
+                // Skip the emit when the StartRaceIn sound is disabled: PlaySound
+                // fires its onFinished callback immediately in that case, so the
+                // delayed-start timeline collapses and the event's expectedStart
+                // would mislead receivers. The race-state stream (RacePreStart /
+                // RaceStart) still carries authoritative timing.
+                if (SoundManager.GetSound(SoundKey.StartRaceIn)?.Enabled == true)
+                {
+                    ExtensionNotifier?.EmitRaceStartAnnouncement(delay, race);
+                }
+
                 SoundManager.StartRaceIn(delay, () =>
                 {
                     // Put in the queue so it definitely happens after preRaceStart

--- a/documentation/POST_Extension_INTERFACE.en.md
+++ b/documentation/POST_Extension_INTERFACE.en.md
@@ -504,6 +504,8 @@ The five `type` values:
 
 `RacePreStart.scheduledStart` is the **exact planned start instant** chosen by `StartRaceInLessThan(MinStartDelay, MaxStartDelay)` — a uniformly distributed pick in `[Now + MinStartDelay, Now + MaxStartDelay]`. The value is delivered before the wait loop runs, so receivers have the full random window (~`MaxStartDelay − MinStartDelay`, minus a few network/serial milliseconds) to prepare their start cues. This is particularly valuable for **accessibility** scenarios: a pilot who is deaf, hard-of-hearing, or running with ambient noise that masks the audio "GO" beep can rely on an LED panel or strobe anchored to `scheduledStart`, getting the same fair start signal as every other pilot — even when the event uses randomised start delays (`MinStartDelay != MaxStartDelay`). Operators can also audit race-start jitter after the fact by comparing `scheduledStart` (from `RacePreStart`) with `actualStart` (from `RaceStart`).
 
+Note: `RacePreStart` is sent **after** the "Arm your quads…" voice prompt finishes, because `OnRaceStartScheduled` only fires inside the post-speech callback that runs `RaceManager.StartRace → StartRaceInLessThan`. Receivers that need to react at the **start** of the voice prompt (e.g. light a panel as the announcement begins) should subscribe to `RaceStartAnnouncement` (§7.10) instead, which fires ≈ `MaxStartDelay` seconds earlier than `RacePreStart`.
+
 ### 7.4 `DetectionExt`
 
 The most frequent event. Fires once per gate detection (sector pass or lap end). Replaces the legacy `DetectionDetails` for Extension purposes; both may be present on the wire when the legacy notifier is also enabled.
@@ -673,6 +675,44 @@ Fires only when a TimeTrial race runs with FPVTrackside's "Time Trial Staggered 
 
 The arrival of this event itself is the staggered-start signal for receivers. No staggered flag is sent in Hello.
 
+### 7.10 `RaceStartAnnouncement`
+
+Fires the instant the "Arm your quads. Starting on the tone in less than {time}" voice prompt begins (`SoundManager.StartRaceIn`). Lets receivers anchor LED/strobe cues at the **start** of the announcement, well before `RacePreStart` arrives.
+
+```json
+{
+  "type": "RaceStartAnnouncement",
+  "ts": "2026-05-23T13:00:00.000Z",
+  "seq": 88,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "delaySeconds": 5.0,
+  "expectedStart": "2026-05-23T13:00:05.000Z"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `round` / `race` | int | Race identifiers |
+| `raceType` | string | C# `EventTypes` enum name |
+| `delaySeconds` | number (seconds) | Value passed to `SoundManager.StartRaceIn(...)` — equals `Event.MaxStartDelay`. Approximates the duration of the spoken announcement; the actual race start occurs after the speech completes plus a randomised wait in `[MinStartDelay, MaxStartDelay]`. |
+| `expectedStart` | string (ISO-8601 UTC) | `ts + delaySeconds`. Convenience value so receivers don't need to add `delaySeconds` to `ts` themselves. Approximate — see "Relationship to `RacePreStart`" below. |
+
+**When it fires.** Only when `EventLayer.StartRace` enters the **delayed-start branch**, which requires all of:
+- `Event.MaxStartDelay + Event.MinStartDelay > 0` (default 5.5 s; if both are 0 the immediate-start branch is taken and no announcement plays)
+- `RaceType.HasDelayedStart() == true` (true for every `EventTypes` except `Freestyle` and `CasualPractice`)
+- `!staggeredStart` (i.e. not the combination `RaceType == TimeTrial` AND `ApplicationProfileSettings.TimeTrialStaggeredStart == true`)
+- **The `StartRaceIn` sound itself is enabled** (`SoundManager.GetSound(SoundKey.StartRaceIn).Enabled == true`). When the sound is disabled, `SoundManager.PlaySound` fires the post-speech callback immediately, which collapses the delayed-start timeline; the announcement event would mislead receivers about the actual race-start moment, so it is suppressed. The authoritative race-state stream (`RacePreStart` / `RaceStart`) is unaffected and continues to flow.
+
+For the staggered TimeTrial path, no `RaceStartAnnouncement` is sent; `PilotStaggeredStart` (§7.9) fires per pilot at their individual go moment instead.
+
+**Relationship to `RacePreStart`.** `RaceStartAnnouncement` is sent first (at speech start), and `RacePreStart` follows ≈ `MaxStartDelay` seconds later when the speech callback runs `RaceManager.StartRace → StartRaceInLessThan → OnRaceStartScheduled`. The `expectedStart` field in this event is therefore an **estimate** of when the race timer will start; the **authoritative** start moment is `RacePreStart.scheduledStart`, which is the post-randomisation pick from `[Now + MinStartDelay, Now + MaxStartDelay]`. Use both events:
+
+- `RaceStartAnnouncement` → light the panel / start an audible-equivalent visual countdown the moment the announcement begins.
+- `RacePreStart.scheduledStart` → refine the exact moment of "GO".
+- `RaceStart.actualStart` → the actual race-timer zero.
+
 ---
 
 ## 8. Time and number formats
@@ -758,6 +798,8 @@ def worker(queue):
             "StageRanking": on_stage_ranking(evt)
             "PilotCrashedOut": on_crash(evt)
             "PilotRaceState":  on_roster_change(evt)
+            "PilotStaggeredStart":   on_staggered_start(evt)
+            "RaceStartAnnouncement": on_start_announcement(evt)
             _: log_debug("ignored type:", evt.type)
 ```
 

--- a/documentation/POST_Extension_INTERFACE.ja.md
+++ b/documentation/POST_Extension_INTERFACE.ja.md
@@ -505,6 +505,8 @@ absolutePath = path.join(config.Fpvt.Paths.WorkingDirectory, pilot.PhotoPath)
 
 `RacePreStart.scheduledStart` は `StartRaceInLessThan(MinStartDelay, MaxStartDelay)` が選んだ**正確な予定スタート瞬間** — `[Now + MinStartDelay, Now + MaxStartDelay]` の一様分布乱数で決定されます。本値は wait ループ実行前に配信されるため、受信側はランダム窓全体（およそ `MaxStartDelay − MinStartDelay` から通信遅延数 ms を引いた時間）をスタート合図準備に使えます。これは特に**アクセシビリティ**用途で価値があります: 聴覚障害者・難聴者、あるいは環境騒音で「Go」のビープ音がマスクされる場面でも、`scheduledStart` に固定された LED パネル／ストロボに頼ることで、他のパイロットと同条件で同じスタート合図を受け取れます — イベントがランダムスタート遅延（`MinStartDelay != MaxStartDelay`）を使う場合でも有効です。`scheduledStart`（`RacePreStart`）と `actualStart`（`RaceStart`）を突き合わせれば、運営側はスタートタイミングのジッタを事後監査することも可能です.
 
+注意: `RacePreStart` は「Arm your quads…」音声アナウンスが**完了した後**に送出されます — `OnRaceStartScheduled` は発声完了コールバック内で実行される `RaceManager.StartRace → StartRaceInLessThan` の中でのみ発火するためです. アナウンス**開始**の瞬間に反応したい受信側（例: 発声開始と同時にパネルを点灯したい LED）は、代わりに `RaceStartAnnouncement`（§7.10）を購読してください. これは `RacePreStart` よりおおよそ `MaxStartDelay` 秒早く送出されます.
+
 ### 7.4 `DetectionExt`
 
 最も高頻度なイベント. ゲート検出（セクター通過またはラップ終端）毎に 1 回発火. Extension 用途では既存の `DetectionDetails` を置き換え. レガシー Notifier も有効な場合、両方が wire 上に流れる.
@@ -674,6 +676,44 @@ absolutePath = path.join(config.Fpvt.Paths.WorkingDirectory, pilot.PhotoPath)
 
 受信側は本イベントの**到着自体**を staggered start のシグナルとして扱える。Hello に staggered フラグは含まれない。
 
+### 7.10 `RaceStartAnnouncement`
+
+「Arm your quads. Starting on the tone in less than {time}」アナウンス音声（`SoundManager.StartRaceIn`）が**発声を開始した瞬間**に発火. アナウンス**開始**に合わせて LED やストロボの合図を出したい受信側のためのイベントで、`RacePreStart` より大幅に早く届きます。
+
+```json
+{
+  "type": "RaceStartAnnouncement",
+  "ts": "2026-05-23T13:00:00.000Z",
+  "seq": 88,
+  "round": 3,
+  "race": 2,
+  "raceType": "Race",
+  "delaySeconds": 5.0,
+  "expectedStart": "2026-05-23T13:00:05.000Z"
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `round` / `race` | int | レース識別子 |
+| `raceType` | string | C# `EventTypes` enum 名 |
+| `delaySeconds` | number（秒） | `SoundManager.StartRaceIn(...)` に渡される値で、`Event.MaxStartDelay` と等しい. アナウンス音声の長さの近似値. 実際のレース開始は発声完了後さらに `[MinStartDelay, MaxStartDelay]` のランダム待機を挟む |
+| `expectedStart` | string（ISO-8601 UTC） | `ts + delaySeconds`. 受信側が自前で加算する手間を省くための補助値. **概算値**であり厳密値は後述の `RacePreStart.scheduledStart` を参照 |
+
+**発火条件.** `EventLayer.StartRace` が **delayed-start ブランチ**に入る場合のみ. 具体的には以下すべてを満たす必要があります:
+- `Event.MaxStartDelay + Event.MinStartDelay > 0`（既定 5.5 秒. 両方 0 だと即時開始ブランチに入り、本イベントは送出されない）
+- `RaceType.HasDelayedStart() == true`（`Freestyle` と `CasualPractice` 以外のすべての `EventTypes` で true）
+- `!staggeredStart`（つまり `RaceType == TimeTrial` かつ `ApplicationProfileSettings.TimeTrialStaggeredStart == true` の組合せ**ではない**）
+- **`StartRaceIn` サウンド自体が有効**（`SoundManager.GetSound(SoundKey.StartRaceIn).Enabled == true`）. サウンドを無効化していると `SoundManager.PlaySound` が発声完了 callback を即座に発火させてしまい delayed-start のタイムラインが崩壊するため、本イベントを送ると `expectedStart` が実際のレース開始と大きくずれて受信側を誤誘導します. そのため本ケースでは送出を抑制します. 厳密なレース状態ストリーム（`RacePreStart` / `RaceStart`）は影響を受けず通常通り流れます.
+
+staggered TimeTrial 経路では `RaceStartAnnouncement` は送出されません. 代わりに各パイロットの go タイミングで `PilotStaggeredStart`（§7.9）が 1 件ずつ送られます.
+
+**`RacePreStart` との関係.** `RaceStartAnnouncement` が先に（発声開始時に）送られ、その後およそ `MaxStartDelay` 秒経過後、音声完了コールバックで `RaceManager.StartRace → StartRaceInLessThan → OnRaceStartScheduled` が走った時点で `RacePreStart` が送出されます. 本イベントの `expectedStart` はあくまで**概算**であり、レースタイマー開始の**厳密な予定時刻**は `RacePreStart.scheduledStart`（`[Now + MinStartDelay, Now + MaxStartDelay]` のランダム値）です. 両イベントを併用してください:
+
+- `RaceStartAnnouncement` → アナウンス開始と同時にパネル点灯 / 視覚カウントダウン開始
+- `RacePreStart.scheduledStart` → 「GO」瞬間の精密化
+- `RaceStart.actualStart` → レースタイマーゼロの確定値
+
 ---
 
 ## 8. 時刻と数値の表現
@@ -758,6 +798,8 @@ def worker(queue):
             "StageRanking": on_stage_ranking(evt)
             "PilotCrashedOut": on_crash(evt)
             "PilotRaceState":  on_roster_change(evt)
+            "PilotStaggeredStart":   on_staggered_start(evt)
+            "RaceStartAnnouncement": on_start_announcement(evt)
             _: log_debug("ignored Type:", evt.Type)
 ```
 


### PR DESCRIPTION
  ---

  ## Summary

  - Add a new `RaceStartAnnouncement` event (INTERFACE §7.10) that fires the
    instant `SoundManager.StartRaceIn` begins speaking the "Arm your quads…"
    prompt. It precedes `RacePreStart` by ≈ `MaxStartDelay` seconds, letting
    LED / strobe receivers anchor visual cues at the announcement start
    rather than after the speech completes.
  - Bound `ExtensionNotifier.Dispose` by clearing the HTTP / serial work
    queues before `WorkQueue.Dispose` so "Back to event selection" no longer
    freezes the UI for several seconds when the receiver is unreachable and
    a race-end backlog is in flight.
  - Mirror the new event into `documentation/POST_Extension_INTERFACE.en.md`
    and the Japanese translation, including a cross-reference from §7.3 that
    clarifies the ordering relative to `RacePreStart`.

  ## Why

  Receivers that drive an LED panel, strobe, or any "visual GO" output want
  to react at the start of the audible announcement, not after it finishes.
  With only `RacePreStart` available today, the visual cue lags the audio by
  the full `MaxStartDelay`, which is exactly the window during which pilots
  expect synchronised cues. `RaceStartAnnouncement` closes that gap.

  The dispose change is a bug fix surfaced while testing the above: with an
  offline receiver, the operator's "Back to event selection" click could
  freeze the UI for tens of seconds while the work queue drained pending
  PUTs at 1500 ms apiece. Clearing the queue first caps the wait at one
  in-flight request.

  ## Conditions for `RaceStartAnnouncement` to fire

  All of the following must hold (matches §7.10 of the spec):
  - `ExtensionMode = true`
  - `EventLayer.StartRace` enters the **delayed-start branch**:
    - `Event.MaxStartDelay + Event.MinStartDelay > 0`
    - `RaceType.HasDelayedStart() == true` (not Freestyle / CasualPractice)
    - Not staggered TimeTrial (`PilotStaggeredStart` covers that path)
  - The `StartRaceIn` sound itself is enabled
    (`SoundManager.GetSound(SoundKey.StartRaceIn).Enabled == true`).
    When disabled, `PlaySound` fires its onFinished callback immediately,
    collapsing the delayed-start timeline; sending the event in that case
    would mislead receivers about the actual race-start moment.

  `RacePreStart` / `RaceStart` continue to flow regardless and remain the
  authoritative source of the planned and actual start instants.

  ## Wire format

  ```json
  {
    "type": "RaceStartAnnouncement",
    "ts": "2026-05-23T13:00:00.000Z",
    "seq": 88,
    "round": 3,
    "race": 2,
    "raceType": "Race",
    "delaySeconds": 5.0,
    "expectedStart": "2026-05-23T13:00:05.000Z"
  }

  expectedStart is an estimate (ts + delaySeconds); the authoritative
  post-randomisation start moment is RacePreStart.scheduledStart.

  Compatibility

  - Pure addition — no existing event field changes
  - Receivers that don't know RaceStartAnnouncement fall under §10's
  "silently ignore unknown types" rule (return 200 OK as normal)
  - Sequence numbering (§5) unaffected

  Test plan

  - With a fixed-delay event (MaxStartDelay > 0) and a reachable
  receiver, confirm RaceStartAnnouncement arrives before
  RacePreStart by roughly MaxStartDelay seconds
  - Staggered TimeTrial does not emit RaceStartAnnouncement
  (only PilotStaggeredStart)
  - Freestyle / CasualPractice does not emit RaceStartAnnouncement
  - With the StartRaceIn sound disabled, the event is suppressed
  and the race still starts normally
  - With the receiver intentionally stopped, clicking "Back to event
  selection" after a race no longer freezes the UI for more than ~1.5s

  ---