### PR TITLE
Bugfix:ArUco overlay: vertical-flip text + show all same-ID detections

### DIFF
--- a/Timing/Aruco/ArucoTimingSettings.cs
+++ b/Timing/Aruco/ArucoTimingSettings.cs
@@ -86,6 +86,11 @@ namespace Timing.Aruco
         [Description("Draw the ArUco detection thread's iterations-per-second on each channel's overlay.")]
         public bool ShowFps { get; set; }
 
+        [Category("Overlay")]
+        [DisplayName("Character Flip Vertical")]
+        [Description("Render the overlay text (ID / size % / FPS) upside-down. Useful when the camera or display is mounted vertically inverted. Text position is unchanged; only the glyphs are flipped.")]
+        public bool CharacterFlipVertical { get; set; }
+
         public ArucoTimingSettings()
         {
             MarkerIds = "0";
@@ -100,6 +105,7 @@ namespace Timing.Aruco
             ShowMarkerId = true;
             ShowMarkerSizePercent = true;
             ShowFps = false;
+            CharacterFlipVertical = true;
         }
 
         public override string ToString()

--- a/UI/Nodes/ChannelsGridNode.cs
+++ b/UI/Nodes/ChannelsGridNode.cs
@@ -133,14 +133,19 @@ namespace UI.Nodes
             }
         }
 
-        public ChannelsGridNode(EventManager eventManager, VideoManager videoManager)
+        public ChannelsGridNode(EventManager eventManager, VideoManager videoManager, bool isPlayback = false)
         {
             SingleRow = false;
 
             channelCreationLock = new object();
             channelInfos = new List<ChannelVideoInfo>();
 
-            arucoTimingManager = new UI.Video.ArucoTimingManager(eventManager.RaceManager.TimingSystemManager, this);
+            // Skip ArUco detection on playback grids — the ReplayNode spawns its own
+            // ChannelsGridNode for recorded video, and running detection there would burn FPS
+            // text into the replay output and fight with the live grid for the global overlay
+            // state (Enabled/ShowFps/cache).
+            if (!isPlayback)
+                arucoTimingManager = new UI.Video.ArucoTimingManager(eventManager.RaceManager.TimingSystemManager, this);
 
             EventManager = eventManager;
             VideoManager = videoManager;

--- a/UI/Video/ArucoFrameOverlay.cs
+++ b/UI/Video/ArucoFrameOverlay.cs
@@ -74,6 +74,12 @@ namespace UI.Video
         public static volatile bool Enabled = false;
 
         /// <summary>
+        /// When true, overlay text (ID / size % / FPS) is rendered upside-down at the same on-screen
+        /// position. Useful for cameras/displays mounted in a vertically-inverted orientation.
+        /// </summary>
+        public static volatile bool FlipTextVertical = true;
+
+        /// <summary>
         /// Latest detection iterations per second, published by <see cref="UI.Video.ArucoTimingManager"/>
         /// once per ~1 s. Drawn in each channel's overlay when <see cref="ShowFps"/> is on.
         /// </summary>
@@ -231,15 +237,23 @@ namespace UI.Video
                         string fpsText = DetectionFps.ToString("F0") + " fps";
                         double fxBase = cropX + 6;
                         double fyBase = cropY + cropH - 6;  // baseline near crop bottom
+                        // Pull the baseline one text-height inward (toward the channel's
+                        // centre) so the FPS label doesn't sit flush against the crop edge.
+                        // Computed in pre-flip visual coords so the offset always moves
+                        // toward centre regardless of MirrorX / FlipY.
+                        OpenCvSharp.Size fpsTextSize = Cv2.GetTextSize(
+                            fpsText, HersheyFonts.HersheySimplex,
+                            fontScale * 1.2, textThickness + 2, out _);
+                        fyBase -= fpsTextSize.Height;
                         if (cached.MirrorX) fxBase = w - 1 - fxBase;
                         if (cached.FlipY)   fyBase = h - 1 - fyBase;
                         Scalar fpsColor = format == SurfaceFormat.Color
                             ? new Scalar(255, 255, 0, 255)   // RGBA: yellow
                             : new Scalar(0, 255, 255, 255);  // BGRA: yellow
                         var fpsOrg = new Point((int)fxBase, (int)fyBase);
-                        // Outline pass for contrast.
-                        Cv2.PutText(mat, fpsText, fpsOrg, HersheyFonts.HersheySimplex, fontScale * 1.2, Scalar.Black, textThickness + 2, LineTypes.AntiAlias);
-                        Cv2.PutText(mat, fpsText, fpsOrg, HersheyFonts.HersheySimplex, fontScale * 1.2, fpsColor, textThickness, LineTypes.AntiAlias);
+                        DrawOverlayText(mat, w, h, fpsText, fpsOrg,
+                                        fontScale * 1.2, fpsColor, textThickness,
+                                        outlineScale: fontScale * 1.2, outlineThickness: textThickness + 2);
                     }
 
                     if (detections == null) return;
@@ -296,7 +310,7 @@ namespace UI.Video
                         if (label != null)
                         {
                             var org = new Point((int)acx, (int)acy - 10);
-                            Cv2.PutText(mat, label, org, HersheyFonts.HersheySimplex, fontScale, color, textThickness, LineTypes.AntiAlias);
+                            DrawOverlayText(mat, w, h, label, org, fontScale, color, textThickness);
                         }
                     }
                 }
@@ -304,6 +318,68 @@ namespace UI.Video
             catch
             {
                 // Never let overlay errors take down the capture thread.
+            }
+        }
+
+        /// <summary>
+        /// Draws antialiased text on <paramref name="mat"/>, optionally with a black outline
+        /// (when <paramref name="outlineThickness"/> &gt; 0) and optionally flipped vertically
+        /// in-place (when <see cref="FlipTextVertical"/> is true). Position of <paramref name="org"/>
+        /// is preserved; only the glyph shape is inverted top-to-bottom.
+        /// </summary>
+        /// <remarks>
+        /// Vertical flip is performed by drawing into a tight ROI on <paramref name="mat"/> and
+        /// applying <see cref="Cv2.Flip"/> with <see cref="FlipMode.X"/>. Background pixels within
+        /// that small ROI are also flipped — invisible for typical glyph-sized rectangles.
+        /// </remarks>
+        private static void DrawOverlayText(Mat mat, int w, int h, string text, Point org,
+                                            double scale, Scalar color, int thickness,
+                                            double outlineScale = 0, int outlineThickness = 0)
+        {
+            const HersheyFonts font = HersheyFonts.HersheySimplex;
+            const LineTypes lineType = LineTypes.AntiAlias;
+            bool hasOutline = outlineThickness > 0;
+
+            if (!FlipTextVertical)
+            {
+                if (hasOutline)
+                    Cv2.PutText(mat, text, org, font, outlineScale, Scalar.Black, outlineThickness, lineType);
+                Cv2.PutText(mat, text, org, font, scale, color, thickness, lineType);
+                return;
+            }
+
+            // Use the wider of (outline, main) for bounding-rect calculation so the flipped
+            // ROI covers both passes. Pad a few pixels for AA fringe.
+            double measureScale = hasOutline ? outlineScale : scale;
+            int measureThickness = hasOutline ? outlineThickness : thickness;
+            OpenCvSharp.Size textSize = Cv2.GetTextSize(text, font, measureScale, measureThickness, out int baseline);
+            const int padding = 2;
+            int rectX = org.X - padding;
+            int rectY = org.Y - textSize.Height - padding;
+            int rectW = textSize.Width + padding * 2;
+            int rectH = textSize.Height + baseline + padding * 2;
+
+            // Clip to image bounds. Fall back to a non-flipped draw if the ROI vanishes.
+            int x0 = Math.Max(0, rectX);
+            int y0 = Math.Max(0, rectY);
+            int x1 = Math.Min(w, rectX + rectW);
+            int y1 = Math.Min(h, rectY + rectH);
+            if (x1 - x0 <= 0 || y1 - y0 <= 0)
+            {
+                if (hasOutline)
+                    Cv2.PutText(mat, text, org, font, outlineScale, Scalar.Black, outlineThickness, lineType);
+                Cv2.PutText(mat, text, org, font, scale, color, thickness, lineType);
+                return;
+            }
+
+            Rect roi = new Rect(x0, y0, x1 - x0, y1 - y0);
+            using (Mat sub = new Mat(mat, roi))
+            {
+                Point adjOrg = new Point(org.X - roi.X, org.Y - roi.Y);
+                if (hasOutline)
+                    Cv2.PutText(sub, text, adjOrg, font, outlineScale, Scalar.Black, outlineThickness, lineType);
+                Cv2.PutText(sub, text, adjOrg, font, scale, color, thickness, lineType);
+                Cv2.Flip(sub, sub, FlipMode.X);
             }
         }
 

--- a/UI/Video/ArucoFrameOverlay.cs
+++ b/UI/Video/ArucoFrameOverlay.cs
@@ -48,26 +48,15 @@ namespace UI.Video
         }
 
         /// <summary>
-        /// Per-channel state: latest geometry (crop/flip/mirror/sizes) plus a list of held markers
-        /// with per-instance timestamps. Held markers are identified by (Id, approximate centre)
-        /// so multiple physical markers sharing the same ID are tracked separately; aging is then
-        /// per-instance, so a brief miss on one of N markers preserves the others.
+        /// Per-channel state: latest geometry (crop/flip/mirror/sizes) plus a snapshot of held
+        /// markers from the most recent detection update. The list is fully replaced on every
+        /// update — no per-instance bridge across detection misses.
         /// </summary>
         private sealed class ChannelEntry
         {
             public Cached Geometry;
             public readonly List<HeldMarker> Markers = new List<HeldMarker>();
         }
-
-        /// <summary>
-        /// Maximum distance (in detection-frame pixels) at which an incoming detection is
-        /// considered to refresh an existing held marker with the same Id (per-instance bridge
-        /// across short detection misses). Beyond this, the detection is added as a new instance
-        /// so duplicate same-Id markers at distinct screen positions each get their own outline.
-        /// Driven by the ArUco timing system's existing "Hybrid Distance Threshold" — both use the
-        /// same "what counts as the same physical marker" criterion, just at different layers.
-        /// </summary>
-        public static volatile int SameMarkerCentreDistancePx = 20;
 
         // Multiple channels can share the same FrameSource (e.g. a single 2x2 capture split
         // by RelativeSourceBounds into 4 pilot views). We therefore index first by FrameSource
@@ -124,54 +113,17 @@ namespace UI.Video
             DateTime now = DateTime.UtcNow;
             lock (entry.Markers)
             {
+                // Snapshot mode: the detector's merged list is the source of truth for the frame.
+                // Per-marker bridging across detection misses is intentionally not done — every
+                // detection update fully replaces the held set, so a missed marker disappears for
+                // one detection cycle instead of being held with a stale outline.
+                entry.Markers.Clear();
                 if (cached.Detections != null)
                 {
                     foreach (var d in cached.Detections)
                     {
                         if (d == null || d.Corners == null || d.Corners.Length == 0) continue;
-
-                        double cx = 0, cy = 0;
-                        for (int i = 0; i < d.Corners.Length; i++)
-                        {
-                            cx += d.Corners[i].X;
-                            cy += d.Corners[i].Y;
-                        }
-                        cx /= d.Corners.Length;
-                        cy /= d.Corners.Length;
-
-                        // Refresh the nearest existing held marker that shares this Id, or add a
-                        // new instance when none is close enough — same-Id markers at distinct
-                        // positions each get their own outline this way. Snapshot the volatile
-                        // threshold once so a mid-loop config change can't desync the comparison.
-                        int radius = SameMarkerCentreDistancePx;
-                        int matchIdx = -1;
-                        double matchDistSq = (double)radius * radius;
-                        for (int i = 0; i < entry.Markers.Count; i++)
-                        {
-                            var held = entry.Markers[i];
-                            if (held.Detection.Id != d.Id || held.Detection.Corners == null || held.Detection.Corners.Length == 0) continue;
-                            double hcx = 0, hcy = 0;
-                            for (int j = 0; j < held.Detection.Corners.Length; j++)
-                            {
-                                hcx += held.Detection.Corners[j].X;
-                                hcy += held.Detection.Corners[j].Y;
-                            }
-                            hcx /= held.Detection.Corners.Length;
-                            hcy /= held.Detection.Corners.Length;
-                            double dx = hcx - cx, dy = hcy - cy;
-                            double distSq = dx * dx + dy * dy;
-                            if (distSq < matchDistSq)
-                            {
-                                matchDistSq = distSq;
-                                matchIdx = i;
-                            }
-                        }
-
-                        var refreshed = new HeldMarker { Detection = d, SeenAt = now };
-                        if (matchIdx >= 0)
-                            entry.Markers[matchIdx] = refreshed;
-                        else
-                            entry.Markers.Add(refreshed);
+                        entry.Markers.Add(new HeldMarker { Detection = d, SeenAt = now });
                     }
                 }
             }
@@ -371,13 +323,14 @@ namespace UI.Video
         /// <summary>
         /// Draws antialiased text on <paramref name="mat"/>, optionally with a black outline
         /// (when <paramref name="outlineThickness"/> &gt; 0) and optionally flipped vertically
-        /// in-place (when <see cref="FlipTextVertical"/> is true). Position of <paramref name="org"/>
+        /// (when <see cref="FlipTextVertical"/> is true). Position of <paramref name="org"/>
         /// is preserved; only the glyph shape is inverted top-to-bottom.
         /// </summary>
         /// <remarks>
-        /// Vertical flip is performed by drawing into a tight ROI on <paramref name="mat"/> and
-        /// applying <see cref="Cv2.Flip"/> with <see cref="FlipMode.X"/>. Background pixels within
-        /// that small ROI are also flipped — invisible for typical glyph-sized rectangles.
+        /// Flip path: glyphs are rendered into an isolated transparent temp Mat, flipped, then
+        /// alpha-composited onto the main mat. This keeps any pre-existing pixels under the
+        /// text's bounding rect — marker outlines, underlying video — untouched, and avoids the
+        /// AA-fringe ghosting that an in-place ROI flip would leave outside the tight rect.
         /// </remarks>
         private static void DrawOverlayText(Mat mat, int w, int h, string text, Point org,
                                             double scale, Scalar color, int thickness,
@@ -395,12 +348,12 @@ namespace UI.Video
                 return;
             }
 
-            // Use the wider of (outline, main) for bounding-rect calculation so the flipped
-            // ROI covers both passes. Pad a few pixels for AA fringe.
+            // Measure with the wider of (outline, main) so the temp Mat covers both passes.
+            // Padding generous enough to hold the AA fringe of the heaviest stroke we draw.
             double measureScale = hasOutline ? outlineScale : scale;
             int measureThickness = hasOutline ? outlineThickness : thickness;
             OpenCvSharp.Size textSize = Cv2.GetTextSize(text, font, measureScale, measureThickness, out int baseline);
-            const int padding = 2;
+            int padding = Math.Max(4, measureThickness + 2);
             int rectX = org.X - padding;
             int rectY = org.Y - textSize.Height - padding;
             int rectW = textSize.Width + padding * 2;
@@ -419,14 +372,39 @@ namespace UI.Video
                 return;
             }
 
-            Rect roi = new Rect(x0, y0, x1 - x0, y1 - y0);
-            using (Mat sub = new Mat(mat, roi))
+            Rect rect = new Rect(x0, y0, x1 - x0, y1 - y0);
+            // Adjust the glyph origin into the temp's local coords. When the rect was clipped at
+            // the image edge, rect.X / rect.Y may differ from the unclipped rectX / rectY — using
+            // rect.* here keeps the glyph centred correctly within whatever portion survived.
+            Point adjOrg = new Point(org.X - rect.X, org.Y - rect.Y);
+            using (Mat temp = new Mat(rect.Height, rect.Width, MatType.CV_8UC4, Scalar.All(0)))
             {
-                Point adjOrg = new Point(org.X - roi.X, org.Y - roi.Y);
                 if (hasOutline)
-                    Cv2.PutText(sub, text, adjOrg, font, outlineScale, Scalar.Black, outlineThickness, lineType);
-                Cv2.PutText(sub, text, adjOrg, font, scale, color, thickness, lineType);
-                Cv2.Flip(sub, sub, FlipMode.X);
+                    Cv2.PutText(temp, text, adjOrg, font, outlineScale, Scalar.Black, outlineThickness, lineType);
+                Cv2.PutText(temp, text, adjOrg, font, scale, color, thickness, lineType);
+                Cv2.Flip(temp, temp, FlipMode.X);
+                AlphaCompositeOnto(mat, rect, temp);
+            }
+        }
+
+        /// <summary>
+        /// Premultiplied-alpha composite of <paramref name="src"/> (8UC4, glyph pixels pre-multiplied
+        /// by AA coverage thanks to PutText into an all-zero buffer) onto the <paramref name="rect"/>
+        /// portion of <paramref name="dst"/>. Equivalent to: dst_roi = src + dst_roi * (255 - src_alpha) / 255.
+        /// </summary>
+        private static void AlphaCompositeOnto(Mat dst, Rect rect, Mat src)
+        {
+            using (Mat alpha = new Mat())
+            using (Mat invAlpha = new Mat())
+            using (Mat invAlphaBgra = new Mat())
+            using (Mat scaledBg = new Mat())
+            using (Mat dstRoi = new Mat(dst, rect))
+            {
+                Cv2.ExtractChannel(src, alpha, 3);
+                Cv2.BitwiseNot(alpha, invAlpha);  // 255 - alpha for 8-bit
+                Cv2.Merge(new[] { invAlpha, invAlpha, invAlpha, invAlpha }, invAlphaBgra);
+                Cv2.Multiply(dstRoi, invAlphaBgra, scaledBg, 1.0 / 255.0);
+                Cv2.Add(scaledBg, src, dstRoi);
             }
         }
 

--- a/UI/Video/ArucoFrameOverlay.cs
+++ b/UI/Video/ArucoFrameOverlay.cs
@@ -48,15 +48,26 @@ namespace UI.Video
         }
 
         /// <summary>
-        /// Per-channel state: latest geometry (crop/flip/mirror/sizes) plus a per-marker-ID
-        /// dictionary of the most recent detection and when it was seen. Aging out markers by ID
-        /// rather than by whole-frame lets a brief miss on one of N markers preserve the others.
+        /// Per-channel state: latest geometry (crop/flip/mirror/sizes) plus a list of held markers
+        /// with per-instance timestamps. Held markers are identified by (Id, approximate centre)
+        /// so multiple physical markers sharing the same ID are tracked separately; aging is then
+        /// per-instance, so a brief miss on one of N markers preserves the others.
         /// </summary>
         private sealed class ChannelEntry
         {
             public Cached Geometry;
-            public readonly Dictionary<int, HeldMarker> Markers = new Dictionary<int, HeldMarker>();
+            public readonly List<HeldMarker> Markers = new List<HeldMarker>();
         }
+
+        /// <summary>
+        /// Maximum distance (in detection-frame pixels) at which an incoming detection is
+        /// considered to refresh an existing held marker with the same Id (per-instance bridge
+        /// across short detection misses). Beyond this, the detection is added as a new instance
+        /// so duplicate same-Id markers at distinct screen positions each get their own outline.
+        /// Driven by the ArUco timing system's existing "Hybrid Distance Threshold" — both use the
+        /// same "what counts as the same physical marker" criterion, just at different layers.
+        /// </summary>
+        public static volatile int SameMarkerCentreDistancePx = 20;
 
         // Multiple channels can share the same FrameSource (e.g. a single 2x2 capture split
         // by RelativeSourceBounds into 4 pilot views). We therefore index first by FrameSource
@@ -117,8 +128,50 @@ namespace UI.Video
                 {
                     foreach (var d in cached.Detections)
                     {
-                        if (d == null || d.Corners == null) continue;
-                        entry.Markers[d.Id] = new HeldMarker { Detection = d, SeenAt = now };
+                        if (d == null || d.Corners == null || d.Corners.Length == 0) continue;
+
+                        double cx = 0, cy = 0;
+                        for (int i = 0; i < d.Corners.Length; i++)
+                        {
+                            cx += d.Corners[i].X;
+                            cy += d.Corners[i].Y;
+                        }
+                        cx /= d.Corners.Length;
+                        cy /= d.Corners.Length;
+
+                        // Refresh the nearest existing held marker that shares this Id, or add a
+                        // new instance when none is close enough — same-Id markers at distinct
+                        // positions each get their own outline this way. Snapshot the volatile
+                        // threshold once so a mid-loop config change can't desync the comparison.
+                        int radius = SameMarkerCentreDistancePx;
+                        int matchIdx = -1;
+                        double matchDistSq = (double)radius * radius;
+                        for (int i = 0; i < entry.Markers.Count; i++)
+                        {
+                            var held = entry.Markers[i];
+                            if (held.Detection.Id != d.Id || held.Detection.Corners == null || held.Detection.Corners.Length == 0) continue;
+                            double hcx = 0, hcy = 0;
+                            for (int j = 0; j < held.Detection.Corners.Length; j++)
+                            {
+                                hcx += held.Detection.Corners[j].X;
+                                hcy += held.Detection.Corners[j].Y;
+                            }
+                            hcx /= held.Detection.Corners.Length;
+                            hcy /= held.Detection.Corners.Length;
+                            double dx = hcx - cx, dy = hcy - cy;
+                            double distSq = dx * dx + dy * dy;
+                            if (distSq < matchDistSq)
+                            {
+                                matchDistSq = distSq;
+                                matchIdx = i;
+                            }
+                        }
+
+                        var refreshed = new HeldMarker { Detection = d, SeenAt = now };
+                        if (matchIdx >= 0)
+                            entry.Markers[matchIdx] = refreshed;
+                        else
+                            entry.Markers.Add(refreshed);
                     }
                 }
             }
@@ -131,26 +184,20 @@ namespace UI.Video
         private static List<MarkerDetection> CollectActive(ChannelEntry entry, DateTime now)
         {
             List<MarkerDetection> active = null;
-            List<int> expired = null;
             lock (entry.Markers)
             {
-                foreach (var kv in entry.Markers)
+                for (int i = entry.Markers.Count - 1; i >= 0; i--)
                 {
-                    double ageMs = (now - kv.Value.SeenAt).TotalMilliseconds;
+                    double ageMs = (now - entry.Markers[i].SeenAt).TotalMilliseconds;
                     if (ageMs > OverlayHoldMs)
                     {
-                        if (expired == null) expired = new List<int>();
-                        expired.Add(kv.Key);
+                        entry.Markers.RemoveAt(i);
                     }
                     else
                     {
                         if (active == null) active = new List<MarkerDetection>();
-                        active.Add(kv.Value.Detection);
+                        active.Add(entry.Markers[i].Detection);
                     }
-                }
-                if (expired != null)
-                {
-                    foreach (var k in expired) entry.Markers.Remove(k);
                 }
             }
             return active;

--- a/UI/Video/ArucoTimingManager.cs
+++ b/UI/Video/ArucoTimingManager.cs
@@ -227,6 +227,7 @@ namespace UI.Video
                         ArucoFrameOverlay.ShowId = primarySettings.ShowMarkerId;
                         ArucoFrameOverlay.ShowSizePercent = primarySettings.ShowMarkerSizePercent;
                         ArucoFrameOverlay.ShowFps = primarySettings.ShowFps;
+                        ArucoFrameOverlay.FlipTextVertical = primarySettings.CharacterFlipVertical;
                     }
                     bool multiThread = primarySettings?.UseMultiThreadDetection ?? true;
 

--- a/UI/Video/ArucoTimingManager.cs
+++ b/UI/Video/ArucoTimingManager.cs
@@ -146,6 +146,11 @@ namespace UI.Video
 
                 while (run)
                 {
+                    // Re-assert each iteration so that another ArucoTimingManager instance's
+                    // shutdown (e.g. the one ReplayNode spawns via its own ChannelsGridNode)
+                    // cannot leave this thread running with the global overlay disabled.
+                    ArucoFrameOverlay.Enabled = true;
+
                     var systems = timingSystemManager.TimingSystems
                         .OfType<ArucoTimingSystem>()
                         .ToArray();

--- a/UI/Video/ArucoTimingManager.cs
+++ b/UI/Video/ArucoTimingManager.cs
@@ -228,6 +228,10 @@ namespace UI.Video
                         ArucoFrameOverlay.ShowSizePercent = primarySettings.ShowMarkerSizePercent;
                         ArucoFrameOverlay.ShowFps = primarySettings.ShowFps;
                         ArucoFrameOverlay.FlipTextVertical = primarySettings.CharacterFlipVertical;
+                        // Reuse HybridDistanceThreshold (the "same physical marker" px) for the
+                        // overlay's per-instance bridge matching. Clamp to >=1 so a 0 config can't
+                        // collapse every same-Id detection into one held marker.
+                        ArucoFrameOverlay.SameMarkerCentreDistancePx = Math.Max(1, primarySettings.HybridDistanceThreshold);
                     }
                     bool multiThread = primarySettings?.UseMultiThreadDetection ?? true;
 

--- a/UI/Video/ArucoTimingManager.cs
+++ b/UI/Video/ArucoTimingManager.cs
@@ -228,10 +228,6 @@ namespace UI.Video
                         ArucoFrameOverlay.ShowSizePercent = primarySettings.ShowMarkerSizePercent;
                         ArucoFrameOverlay.ShowFps = primarySettings.ShowFps;
                         ArucoFrameOverlay.FlipTextVertical = primarySettings.CharacterFlipVertical;
-                        // Reuse HybridDistanceThreshold (the "same physical marker" px) for the
-                        // overlay's per-instance bridge matching. Clamp to >=1 so a 0 config can't
-                        // collapse every same-Id detection into one held marker.
-                        ArucoFrameOverlay.SameMarkerCentreDistancePx = Math.Max(1, primarySettings.HybridDistanceThreshold);
                     }
                     bool multiThread = primarySettings?.UseMultiThreadDetection ?? true;
 

--- a/UI/Video/ReplayNode.cs
+++ b/UI/Video/ReplayNode.cs
@@ -261,7 +261,7 @@ namespace UI.Video
                 PlaybackVideoManager = VideoManagerFactory.CreateVideoManager();
                 PlaybackVideoManager.OnStart += PlaybackVideoManager_OnStart;
 
-                ChannelsGridNode = new ChannelsGridNode(EventManager, PlaybackVideoManager);
+                ChannelsGridNode = new ChannelsGridNode(EventManager, PlaybackVideoManager, isPlayback: true);
                 ChannelsGridNode.RelativeBounds = new RectangleF(0, 0, 1, 1 - seekBarHeight);
                 AddChild(ChannelsGridNode);
 

--- a/WindowsMediaPlatform/DirectShow/DirectShowFrameSource.cs
+++ b/WindowsMediaPlatform/DirectShow/DirectShowFrameSource.cs
@@ -290,9 +290,14 @@ namespace WindowsMediaPlatform.DirectShow
 
                     long sampleTicks = (long)(sampleTime * 10000000);
 
-                    // Overlay hook: mutate the DirectShow sample buffer in place before the
-                    // display copy. Recording is through a separate DirectShow filter graph
-                    // and is not affected here.
+                    // Overlay hook: mutate the SampleGrabber's display buffer in place.
+                    // NOTE: when this source is DirectShowCaptureFrameSource, recording runs through
+                    // a parallel branch of the filter graph (SmartTee → SinkFilter → GMFBridge →
+                    // DestinationGraph), which receives its own buffer copies upstream of here, so
+                    // this overlay does NOT appear in DirectShow-recorded files.
+                    // The MediaFoundationDSCaptureFrameSource subclass *does* pick up the overlay
+                    // because it records by forwarding the same buffer mutated here into an
+                    // IMFSinkWriter (see MediaFoundationDSCaptureFrameSource.BufferCB).
                     ImageServer.FrameSource.BeforeFrameDispatchPtr?.Invoke(this, buffer, bufferLen);
 
                     frame.SetData(buffer, sampleTicks, FrameProcessNumber);

--- a/WindowsMediaPlatform/MediaFoundation/MediaFoundationFrameSource.cs
+++ b/WindowsMediaPlatform/MediaFoundation/MediaFoundationFrameSource.cs
@@ -254,8 +254,13 @@ namespace WindowsMediaPlatform.MediaFoundation
                             hr = buffer.Lock(out intPtr, out length, out current);
                             MFError.ThrowExceptionForHR(hr);
 
-                            // Overlay hook: mutate the sample buffer in place so both the
-                            // display copy below and the sink writer recording see the overlay.
+                            // Overlay hook: mutate the RGB32 sample buffer in place.
+                            // NOTE: this is the post-color-conversion RGB32 buffer used for display.
+                            // MediaFoundationCaptureFrameSource.ProcessUncompressed passes the
+                            // *original* (pre-conversion, typically NV12) sample to recorder.WriteSample,
+                            // so the recording does NOT see this overlay when a colorProcessor is in use
+                            // (i.e. the normal webcam path). Overlay-in-recording is currently only
+                            // guaranteed when colorProcessor == null, which is rare for capture sources.
                             ImageServer.FrameSource.BeforeFrameDispatchPtr?.Invoke(this, intPtr, length);
 
                             frame.SetData(intPtr, sampleTime, FrameProcessNumber);


### PR DESCRIPTION
 ## Summary

  Three related improvements to the ArUco timing system's on-frame overlay (`UI/Video/ArucoFrameOverlay.cs`):

  - **Vertically flipped overlay text** — new `Character Flip Vertical` setting (default ON) renders ID / size % / FPS
  labels upside-down so they read correctly on cameras or displays mounted in a vertically-inverted orientation. Marker
  outlines (polylines) are intentionally not flipped. Flip is done by rendering glyphs into an isolated temp BGRA Mat
  and alpha-compositing them back onto the main mat, so the marker box and the underlying video pixels overlapping the
  text's bounding rect stay untouched, and the AA fringe leaves no pre-flip ghost.
  - **FPS label inset** — the FPS baseline is pulled one text-height inward (toward the channel's centre) before
  mirror/flip is applied, so it no longer sits flush against the crop edge.
  - **All same-ID detections drawn** — replace the per-Id `Dictionary<int, HeldMarker>` overlay cache with a per-frame
  snapshot of the detector's Hybrid-merged `List<MarkerDetection>`. Multiple physical markers sharing one ID at distinct
   screen positions now each get their own outline instead of the latest detection silently collapsing the others.
  Per-marker bridge across detection misses is dropped in exchange for simpler semantics; OverlayHoldMs still gates the
  "no detection updates" case.

## Changes

  - `Timing/Aruco/ArucoTimingSettings.cs` — new `CharacterFlipVertical` setting in the `Overlay` category (default
  `true`).
  - `UI/Video/ArucoFrameOverlay.cs`
    - `FlipTextVertical` static field + `DrawOverlayText` helper (temp Mat + alpha composite).
    - `ChannelEntry.Markers` switched from `Dictionary<int, HeldMarker>` to `List<HeldMarker>`; `SetLatestDetections`
  clears and snapshots the new list each call.
  - `UI/Video/ArucoTimingManager.cs` — plumbs `CharacterFlipVertical` into `ArucoFrameOverlay.FlipTextVertical`.
  
<img width="541" height="398" alt="image" src="https://github.com/user-attachments/assets/e4db8bfa-6370-4370-8bc9-8592ba263696" />

<img width="576" height="424" alt="image" src="https://github.com/user-attachments/assets/71bb5700-8f8a-487c-b401-81a0b93c0a4e" />

  ## Follow-up commits

  Two additional fixes layered on top of the original three:

  ### Live overlay survives replay (commit `7ddfa359`)

  `ReplayNode` spawns its own `ChannelsGridNode`, which until now unconditionally constructed an `ArucoTimingManager`.
  Two consequences:

  - The replay detection thread wrote `ShowFps` / cache into the global overlay state and burned the FPS readout onto
  recorded video during playback.
  - Its shutdown set `ArucoFrameOverlay.Enabled = false` and `ClearAll()`'d the cache, leaving the still-running live
  thread silenced because `Enabled` was only set once outside the loop.

  Fixes:

  - `ChannelsGridNode` ctor takes a new `isPlayback` flag; `ReplayNode` passes `true`, skipping `ArucoTimingManager`
  construction for playback grids.
  - Live `Process()` re-asserts `Enabled = true` at the top of each iteration so a sibling instance's cleanup cannot
  silently disable the overlay.

  ### Honest hook-site comments (commit `922e644f`)

  The pre-existing comments at the two `BeforeFrameDispatchPtr` hook sites overstated which capture paths actually bake
  the overlay into the recording. Updated to reflect actual behaviour:

  - `MediaFoundationFrameSource`: the overlay is applied to the post-color-conversion RGB32 sample, but
  `MediaFoundationCaptureFrameSource` records the *original* pre-conversion sample, so the overlay only reaches the
  recording when `colorProcessor` is null (rare for capture sources).
  - `DirectShowFrameSource`: only `DirectShowCaptureFrameSource` is affected by the SmartTee/GMFBridge separation. The
  `MediaFoundationDSCaptureFrameSource` subclass forwards the same mutated buffer into an `IMFSinkWriter` and therefore
  *does* record the overlay.

  Comments only; no code change.
