### PR TITLE
ArUco: skip detection on idle (non-racing / unassigned) channels during a race

### DIFF
--- a/UI/Video/ArucoTimingManager.cs
+++ b/UI/Video/ArucoTimingManager.cs
@@ -236,12 +236,29 @@ namespace UI.Video
                     }
                     bool multiThread = primarySettings?.UseMultiThreadDetection ?? true;
 
+                    // Only detect on channels of pilots actually racing while a race is running
+                    // (start -> end, including abort). Unassigned channels typically show RF
+                    // static, which is extremely expensive for ArUco (huge contour counts), so
+                    // feed those a black frame instead. Outside a running race, detect on all.
+                    var raceManager = channelNodes[0].EventManager?.RaceManager;
+                    bool raceRunning = raceManager != null && raceManager.RaceRunning;
+                    var currentRace = raceManager?.CurrentRace;
+
                     // Phase 1: collect BGRA buffers from each FrameNodeThumb sequentially
                     // (GetColorData can race with the UI draw thread; do it once up front).
                     var inputs = new (ChannelVideoNode cvn, byte[] bgra)[channelNodes.Length];
                     for (int i = 0; i < channelNodes.Length; i++)
                     {
                         var cvn = channelNodes[i];
+
+                        // Black frame (zero buffer) for non-racing / unassigned channels during a race.
+                        if (raceRunning &&
+                            !(cvn.Pilot != null && currentRace != null && currentRace.HasPilot(cvn.Pilot)))
+                        {
+                            inputs[i] = (cvn, new byte[FrameWidth * FrameHeight * 4]);
+                            continue;
+                        }
+
                         Color[] pixels = cvn.FrameNode.GetColorData();
                         if (pixels == null)
                         {


### PR DESCRIPTION
  ## Summary
  ArUco detection runs on each channel's entire video feed, every frame.
  Unassigned channels show RF static (noise), which generates a huge number of
  contours and makes ArUco detection extremely expensive.

  This PR feeds a black frame to channels that are **not racing** (including
  unassigned channels) **while a race is running (start → end, including abort)**,
  so detection on those channels returns immediately and CPU load drops.

  ## Changes
  - In `ArucoTimingManager.Process()` Phase 1 (BGRA buffer collection), while
    `RaceManager.RaceRunning`, any channel whose pilot is not in the current race
    (`!CurrentRace.HasPilot(pilot)`, including channels with no pilot assigned) is
    replaced with a zeroed (black) BGRA buffer instead of the live frame.
  - A black frame produces no contours, so detection returns an empty result
    instantly and that channel's overlay is cleared (zero markers reported).

  ## Scope / non-goals
  - **No effect on what is displayed on screen** — only the buffer handed to the
    detector is swapped; the rendered video is untouched.
  - Outside a running race, and for channels of pilots who *are* racing, detection
    runs on the full frame exactly as before.
  - No limit on the number of racing pilots. If every channel has a racing pilot,
    zero channels are blacked out and behaviour is identical to before (no
    regression).

  ## Impact
  - Savings scale with the number of idle (static) channels.
  - Detection becomes more efficient, and processing speed improves.
