### PR TITLE
Fix pasted races jumping race number when clicked

### DIFF
--- a/RaceLib/RacePaste.cs
+++ b/RaceLib/RacePaste.cs
@@ -78,5 +78,11 @@ namespace RaceLib
         public string Name { get; set; }
 
         public int ExternalPilotID { get; set; }
+
+        // Optional VTX channel label for this seat, e.g. "R1", "F3", "L2", or a
+        // band+number like "Raceband 1". When present (and resolvable against the
+        // event's channels), the pilot is assigned to that channel instead of the
+        // auto-cycled one. Empty/unresolvable falls back to auto-assignment.
+        public string Channel { get; set; }
     }
 }

--- a/RaceLib/RoundManager.cs
+++ b/RaceLib/RoundManager.cs
@@ -236,11 +236,18 @@ namespace RaceLib
                             if (pp.ExternalPilotID != 0)
                                 p.ExternalID = pp.ExternalPilotID;
 
-                            Channel c = EventManager.GetChannel(p);
-                            Channel chosen = EventManager.GetChannelGroup(channelIndex)
-                                ?.FirstOrDefault(ch => ch.Band.GetBandType() == c.Band.GetBandType());
-                            if (chosen != null)
-                                c = chosen;
+                            // An explicit pasted channel (e.g. "R1") wins — assign the
+                            // pilot to that exact channel from the event's set. Fall back
+                            // to the auto-cycled channel group when absent/unresolvable.
+                            Channel c = ResolveChannelLabel(pp.Channel, EventManager.Channels);
+                            if (c == null)
+                            {
+                                c = EventManager.GetChannel(p);
+                                Channel chosen = EventManager.GetChannelGroup(channelIndex)
+                                    ?.FirstOrDefault(ch => ch.Band.GetBandType() == c.Band.GetBandType());
+                                if (chosen != null)
+                                    c = chosen;
+                            }
 
                             race.SetPilot(db, c, p);
                         }
@@ -254,6 +261,35 @@ namespace RaceLib
             {
                 RaceManager.AddRace(r);
             }
+        }
+
+        // ResolveChannelLabel maps a pasted channel label to one of the event's
+        // channels. Accepts the canonical band+number text ("R1", "F3", "L2"), the
+        // channel's display name, and the long form ("Raceband 1"), matched case-
+        // and space-insensitively. Returns null when the label is empty or doesn't
+        // match a channel in the event's set (caller then auto-assigns).
+        public static Channel ResolveChannelLabel(string label, IEnumerable<Channel> eventChannels)
+        {
+            if (string.IsNullOrWhiteSpace(label) || eventChannels == null)
+                return null;
+
+            string Norm(string s) => (s ?? "").Replace(" ", "").Replace("-", "").ToLowerInvariant();
+            string want = Norm(label);
+            if (want.Length == 0)
+                return null;
+
+            foreach (Channel c in eventChannels)
+            {
+                if (c == null)
+                    continue;
+                if (want == Norm(c.GetBandChannelText()) ||
+                    want == Norm(c.DisplayName) ||
+                    want == Norm(c.ToStringShort()))
+                {
+                    return c;
+                }
+            }
+            return null;
         }
 
         public IEnumerable<Round> GetRoundsBetween(Round start, Round end)

--- a/RaceLib/RoundManager.cs
+++ b/RaceLib/RoundManager.cs
@@ -184,7 +184,11 @@ namespace RaceLib
                     if (race == null || !race.IsFrequencyFree(c))
                     {
                         race = new Race(Event);
-                        race.AutoAssignNumbers = true;
+                        // Pasted races have explicit, correct race numbers. Do NOT flag
+                        // AutoAssignNumbers: that makes a later AddPilot (e.g. when the
+                        // race is opened / made current) renumber the race to max+1,
+                        // which is the "Race 9-1 jumps to 9-7" bug.
+                        race.AutoAssignNumbers = false;
                         race.RaceNumber = startNumber + 1 + races.Count;
                         race.Round = round;
                         races.Add(race);
@@ -213,7 +217,10 @@ namespace RaceLib
                         continue;
 
                     Race race = new Race(Event);
-                    race.AutoAssignNumbers = true;
+                    // See the note on the other overload: pasted races keep their own
+                    // numbers, so AutoAssignNumbers must stay false or opening the race
+                    // later renumbers it to max+1.
+                    race.AutoAssignNumbers = false;
                     race.RaceNumber = startNumber + 1 + races.Count;
                     race.Round = round;
                     race.ExternalID = pasted.ExternalRaceID;


### PR DESCRIPTION
Pasted races were flagged AutoAssignNumbers=true. Opening a race makes it current and re-adds any pilot whose channel differs, and AddPilot then renumbers an AutoAssignNumbers race to max+1 - so a pasted Race 9-1 jumped to 9-7. Pasted races already have explicit, correct numbers, so set AutoAssignNumbers=false in both SetRoundPilots overloads.