### PR TITLE
Add a "Legacy UVC Assign" option to assign identical same-name USB (UVC) VRXes by order

### DIFF
--- a/ImageServer/VideoConfig.cs
+++ b/ImageServer/VideoConfig.cs
@@ -85,6 +85,16 @@ namespace ImageServer
         [System.ComponentModel.Browsable(false)]
         public string ffmpegId { get; set; }
 
+        // Runtime-only override of the device path used to bind to a connected capture
+        // device. Set by VideoManager when the "Legacy UVC Assign" option
+        // is enabled, so that identical same-name cameras each bind to a distinct device
+        // even when their saved paths have gone stale. Never serialized: the saved
+        // DirectShowPath/MediaFoundationPath are left untouched. Null = use the saved path.
+        [System.ComponentModel.Browsable(false)]
+        [JsonIgnore]
+        [XmlIgnore]
+        public string RuntimeDevicePath { get; set; }
+
         [Category("Device")]
         public string URL { get; set; }
 

--- a/UI/ApplicationProfileSettings.cs
+++ b/UI/ApplicationProfileSettings.cs
@@ -72,6 +72,10 @@ namespace UI
         [DisplayName("Video recordings to keep")]
         [Category("Video")]
         public int VideosToKeep { get; set; }
+        [Category("Video")]
+        [DisplayName("Legacy UVC Assign")]
+        [NeedsRestart]
+        public bool LegacyUVCAssign { get; set; }
         [Category("Data")]
         [NeedsRestart]
         public string EventStorageLocation { get; set; }

--- a/UI/ApplicationProfileSettings.cs
+++ b/UI/ApplicationProfileSettings.cs
@@ -72,11 +72,7 @@ namespace UI
         [DisplayName("Video recordings to keep")]
         [Category("Video")]
         public int VideosToKeep { get; set; }
-        [Category("Video")]
-        [DisplayName("Legacy UVC Assign")]
-        [NeedsRestart]
-        public bool LegacyUVCAssign { get; set; }
-        [Category("Data")]
+[Category("Data")]
         [NeedsRestart]
         public string EventStorageLocation { get; set; }
 

--- a/UI/Video/VideoManager.cs
+++ b/UI/Video/VideoManager.cs
@@ -589,9 +589,13 @@ namespace UI.Video
             DoOnWorkerThread(() =>
             {
                 IEnumerable<VideoConfig> toCreate = videoConfigs;
-                if (ApplicationProfileSettings.Instance != null && ApplicationProfileSettings.Instance.LegacyUVCAssign)
+                bool hasDuplicates = videoConfigs
+                    .Where(v => IsOrdinalMatchable(v))
+                    .GroupBy(v => v.DeviceName?.Trim(), StringComparer.OrdinalIgnoreCase)
+                    .Any(g => g.Count() > 1);
+                if (hasDuplicates)
                 {
-                    toCreate = ResolveSameNameDevices(videoConfigs);
+                    toCreate = AssignDuplicateDevices(videoConfigs);
                 }
 
                 List<FrameSource> list = new List<FrameSource>();
@@ -609,16 +613,7 @@ namespace UI.Video
             });
         }
 
-        /// <summary>
-        /// When the "Legacy UVC Assign" option is enabled, make sure that
-        /// configs which share a DeviceName each bind to a distinct connected device.
-        /// Configs whose saved device path still matches a connected device keep it; the
-        /// remaining configs are assigned, in order, to the still-unclaimed connected
-        /// same-name devices via a runtime-only path override (RuntimeDevicePath). The
-        /// saved DirectShowPath/MediaFoundationPath are never modified, so settings files
-        /// are left untouched. Only DirectShow and MediaFoundation configs are affected.
-        /// </summary>
-        private IEnumerable<VideoConfig> ResolveSameNameDevices(IEnumerable<VideoConfig> videoConfigs)
+        private IEnumerable<VideoConfig> AssignDuplicateDevices(IEnumerable<VideoConfig> videoConfigs)
         {
             VideoConfig[] configs = videoConfigs.ToArray();
 
@@ -677,7 +672,7 @@ namespace UI.Video
                 {
                     claimed.Add(DeviceKey(candidate));
                     config.RuntimeDevicePath = StoredDevicePath(candidate);
-                    Logger.VideoLog.Log(this, "LegacyUVCAssign: assigned '" + config.DeviceName + "' to " + config.RuntimeDevicePath);
+                    Logger.VideoLog.Log(this, "Duplicate UVC: assigned '" + config.DeviceName + "' to " + config.RuntimeDevicePath);
                 }
             }
 

--- a/UI/Video/VideoManager.cs
+++ b/UI/Video/VideoManager.cs
@@ -588,8 +588,14 @@ namespace UI.Video
         {
             DoOnWorkerThread(() =>
             {
+                IEnumerable<VideoConfig> toCreate = videoConfigs;
+                if (ApplicationProfileSettings.Instance != null && ApplicationProfileSettings.Instance.LegacyUVCAssign)
+                {
+                    toCreate = ResolveSameNameDevices(videoConfigs);
+                }
+
                 List<FrameSource> list = new List<FrameSource>();
-                foreach (var videoConfig in videoConfigs)
+                foreach (var videoConfig in toCreate)
                 {
                     RemoveFrameSource(videoConfig);
                     FrameSource fs = CreateFrameSource(videoConfig);
@@ -601,6 +607,103 @@ namespace UI.Video
                     frameSourcesDelegate(list);
                 }
             });
+        }
+
+        /// <summary>
+        /// When the "Legacy UVC Assign" option is enabled, make sure that
+        /// configs which share a DeviceName each bind to a distinct connected device.
+        /// Configs whose saved device path still matches a connected device keep it; the
+        /// remaining configs are assigned, in order, to the still-unclaimed connected
+        /// same-name devices via a runtime-only path override (RuntimeDevicePath). The
+        /// saved DirectShowPath/MediaFoundationPath are never modified, so settings files
+        /// are left untouched. Only DirectShow and MediaFoundation configs are affected.
+        /// </summary>
+        private IEnumerable<VideoConfig> ResolveSameNameDevices(IEnumerable<VideoConfig> videoConfigs)
+        {
+            VideoConfig[] configs = videoConfigs.ToArray();
+
+            // Recompute from scratch every time: clear any previous runtime resolution.
+            foreach (VideoConfig vc in configs)
+            {
+                vc.RuntimeDevicePath = null;
+            }
+
+            List<VideoConfig> live;
+            try
+            {
+                live = GetAvailableVideoSources().ToList();
+            }
+            catch (Exception e)
+            {
+                Logger.VideoLog.LogException(this, e);
+                return configs;
+            }
+
+            HashSet<string> claimed = new HashSet<string>();
+
+            // Pass 1: configs whose saved path matches a connected device claim that device.
+            foreach (VideoConfig config in configs)
+            {
+                if (!IsOrdinalMatchable(config))
+                    continue;
+
+                string savedPath = StoredDevicePath(config);
+                VideoConfig match = live.FirstOrDefault(l => l.FrameWork == config.FrameWork
+                    && !string.IsNullOrEmpty(savedPath) && StoredDevicePath(l) == savedPath);
+                if (match != null)
+                {
+                    claimed.Add(DeviceKey(match));
+                }
+            }
+
+            // Pass 2: configs whose saved path no longer matches get the next unclaimed same-name device.
+            foreach (VideoConfig config in configs)
+            {
+                if (!IsOrdinalMatchable(config))
+                    continue;
+
+                string savedPath = StoredDevicePath(config);
+                bool alreadyConnected = !string.IsNullOrEmpty(savedPath)
+                    && live.Any(l => l.FrameWork == config.FrameWork && StoredDevicePath(l) == savedPath);
+                if (alreadyConnected)
+                    continue;
+
+                VideoConfig candidate = live.FirstOrDefault(l => l.FrameWork == config.FrameWork
+                    && string.Equals(l.DeviceName == null ? null : l.DeviceName.Trim(), config.DeviceName == null ? null : config.DeviceName.Trim(), StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrEmpty(StoredDevicePath(l))
+                    && !claimed.Contains(DeviceKey(l)));
+
+                if (candidate != null)
+                {
+                    claimed.Add(DeviceKey(candidate));
+                    config.RuntimeDevicePath = StoredDevicePath(candidate);
+                    Logger.VideoLog.Log(this, "LegacyUVCAssign: assigned '" + config.DeviceName + "' to " + config.RuntimeDevicePath);
+                }
+            }
+
+            return configs;
+        }
+
+        private static bool IsOrdinalMatchable(VideoConfig config)
+        {
+            return config != null
+                && string.IsNullOrEmpty(config.FilePath)
+                && (config.FrameWork == FrameWork.DirectShow || config.FrameWork == FrameWork.MediaFoundation);
+        }
+
+        private static string StoredDevicePath(VideoConfig config)
+        {
+            switch (config.FrameWork)
+            {
+                case FrameWork.DirectShow: return config.DirectShowPath;
+                case FrameWork.MediaFoundation: return config.MediaFoundationPath;
+                default: return null;
+            }
+        }
+
+        private static string DeviceKey(VideoConfig config)
+        {
+            return config.FrameWork + "|" + StoredDevicePath(config);
         }
 
         public void Initialize(FrameSource frameSource)

--- a/WindowsMediaPlatform/DirectShow/DirectShowDeviceFrameSource.cs
+++ b/WindowsMediaPlatform/DirectShow/DirectShowDeviceFrameSource.cs
@@ -51,8 +51,7 @@ namespace WindowsMediaPlatform.DirectShow
         {
             IBaseFilter filter;
 
-            // Bind to the runtime-resolved device path when set (LegacyUVCAssign),
-            // otherwise the saved DirectShowPath. RuntimeDevicePath is null unless that option is on.
+            // RuntimeDevicePath is set when duplicate same-name devices are auto-assigned; fall back to saved path.
             string bindPath = string.IsNullOrEmpty(VideoConfig.RuntimeDevicePath) ? VideoConfig.DirectShowPath : VideoConfig.RuntimeDevicePath;
             DsDevice device = DirectShowHelper.GetVideoCaptureDeviceByPath(bindPath);
             if (device == null)

--- a/WindowsMediaPlatform/DirectShow/DirectShowDeviceFrameSource.cs
+++ b/WindowsMediaPlatform/DirectShow/DirectShowDeviceFrameSource.cs
@@ -51,7 +51,10 @@ namespace WindowsMediaPlatform.DirectShow
         {
             IBaseFilter filter;
 
-            DsDevice device = DirectShowHelper.GetVideoCaptureDeviceByPath(VideoConfig.DirectShowPath);
+            // Bind to the runtime-resolved device path when set (LegacyUVCAssign),
+            // otherwise the saved DirectShowPath. RuntimeDevicePath is null unless that option is on.
+            string bindPath = string.IsNullOrEmpty(VideoConfig.RuntimeDevicePath) ? VideoConfig.DirectShowPath : VideoConfig.RuntimeDevicePath;
+            DsDevice device = DirectShowHelper.GetVideoCaptureDeviceByPath(bindPath);
             if (device == null)
             {
                 if (VideoConfig.AnyUSBPort)

--- a/WindowsMediaPlatform/MediaFoundation/MediaFoundationDeviceFrameSource.cs
+++ b/WindowsMediaPlatform/MediaFoundation/MediaFoundationDeviceFrameSource.cs
@@ -129,7 +129,10 @@ namespace WindowsMediaPlatform.MediaFoundation
 
         private HResult SetupDevice()
         {
-            MFDevice found = MFHelper.GetVideoCaptureDeviceByPath(VideoConfig.MediaFoundationPath);
+            // Bind to the runtime-resolved device path when set (LegacyUVCAssign),
+            // otherwise the saved MediaFoundationPath. RuntimeDevicePath is null unless that option is on.
+            string bindPath = string.IsNullOrEmpty(VideoConfig.RuntimeDevicePath) ? VideoConfig.MediaFoundationPath : VideoConfig.RuntimeDevicePath;
+            MFDevice found = MFHelper.GetVideoCaptureDeviceByPath(bindPath);
             HResult hr = HResult.E_FAIL;
 
             if (found != null)

--- a/WindowsMediaPlatform/MediaFoundation/MediaFoundationDeviceFrameSource.cs
+++ b/WindowsMediaPlatform/MediaFoundation/MediaFoundationDeviceFrameSource.cs
@@ -129,8 +129,7 @@ namespace WindowsMediaPlatform.MediaFoundation
 
         private HResult SetupDevice()
         {
-            // Bind to the runtime-resolved device path when set (LegacyUVCAssign),
-            // otherwise the saved MediaFoundationPath. RuntimeDevicePath is null unless that option is on.
+            // RuntimeDevicePath is set when duplicate same-name devices are auto-assigned; fall back to saved path.
             string bindPath = string.IsNullOrEmpty(VideoConfig.RuntimeDevicePath) ? VideoConfig.MediaFoundationPath : VideoConfig.RuntimeDevicePath;
             MFDevice found = MFHelper.GetVideoCaptureDeviceByPath(bindPath);
             HResult hr = HResult.E_FAIL;


### PR DESCRIPTION
 ## Background / Problem

  Some users connect several identical USB (UVC) VRXes (FPV video receivers,
  e.g. the Eachine ROTG series) that have no serial number, in order to capture
  each pilot's channel simultaneously. These show up as UVC capture devices
  (usually all with the same name, e.g. "USB2.0 PC CAMERA").

  The only thing that distinguishes one device from another is its device path
  (DirectShowPath / MediaFoundationPath), but the USB instance ID contained in
  that path changes on reboot, reconnection, or a port change.

  Once a saved path no longer matches a connected device, the current binding:

  - normally fails to find the device, so it does not show up; and
  - the `AnyUSBPort` name fallback does not help either, because
    `GetVideoCaptureDeviceByName` returns null when more than one device shares
    the name — so **only one of N identical devices ends up shown**.

  **This setup used to work in older versions, but since the move of video
  processing to Core and the refactoring around combine video sources, multiple
  same-name devices can no longer be handled for the reasons above (a
  regression).** This PR restores that behaviour as an opt-in option that does
  not affect existing behaviour.

  ## Solution

  Adds an opt-in setting **`LegacyUVCAssign`** (UI label "Legacy UVC Assign";
  default off; requires restart).

  When enabled, `VideoManager.ResolveSameNameDevices`:

  1. keeps configs whose saved path still matches a connected device as-is; and
  2. assigns each remaining config, one-to-one, to the next unclaimed connected
     device of the same name, in enumeration order.

  The assignment only overrides the device path via a runtime-only
  `RuntimeDevicePath` (not serialized); the saved DirectShowPath /
  MediaFoundationPath and the settings files are never modified.

  As a result, **when off, the code path is identical to today's**, so there is
  no impact on existing users.

  ## Changes

  - `ApplicationProfileSettings`: new `LegacyUVCAssign` flag (Video category).
  - `VideoConfig`: non-serialized `RuntimeDevicePath` (`[XmlIgnore][JsonIgnore]`).
  - `DirectShowDeviceFrameSource` / `MediaFoundationDeviceFrameSource`: bind to
    `RuntimeDevicePath` when it is set (otherwise the saved path, as before).
  - `VideoManager`: `ResolveSameNameDevices` plus helpers, gated by the flag.

  ## Compatibility / Safety

  - Default off. When off, the new code is not entered; behaviour and code path
    are exactly as before.
  - `VideoSettings.xml` is not modified whether the option is on or off.
  - Only a single bool element is added to `ProfileSettings.xml`; thanks to
    XmlSerializer's forward/backward compatibility, downgrading is safe too.

  ## Testing

  - Verified with four identical, serial-less USB VRXes.
  - Off: behaves as before.
  - On: even when the saved paths have gone stale, all four are assigned to
    distinct devices and shown.

  ## Known limitations

  - Because serial-less VRXes cannot be told apart physically, which physical
    VRX maps to which channel may change across reconnections (it depends on
    connection order). This feature guarantees that all of them can be shown and
    used (as long as they are shown, in the worst case you can just change the
    frequency setting on each VRX to match).
  - Applies to DirectShow / MediaFoundation device configs only (ffmpeg, etc.,
    are out of scope).