### PR TITLE
Improve DJI channels management

### DIFF
--- a/RaceLib/Channel.cs
+++ b/RaceLib/Channel.cs
@@ -260,13 +260,13 @@ namespace RaceLib
             new Channel(40, 8, Band.DJIFPVHD),
         };
         public static Channel[] DJIO3 = new Channel[] {
-            new Channel(75, 1, Band.DJIO3),
-            new Channel(76, 2, Band.DJIO3),
-            new Channel(77, 3, Band.DJIO3),
-            new Channel(78, 4, Band.DJIO3),
-            new Channel(79, 5, Band.DJIO3),
-            new Channel(80, 6, Band.DJIO3),
-            new Channel(81, 7, Band.DJIO3),
+            new Channel(75, 'O', 1, Band.DJIO3),
+            new Channel(76, 'O', 2, Band.DJIO3),
+            new Channel(77, 'O', 3, Band.DJIO3),
+            new Channel(78, 'O', 4, Band.DJIO3),
+            new Channel(79, 'O', 5, Band.DJIO3),
+            new Channel(80, 'O', 6, Band.DJIO3),
+            new Channel(81, 'O', 7, Band.DJIO3),
         };
 
         public static Channel[] DJIO4 = new Channel[] {

--- a/RaceLib/Channel.cs
+++ b/RaceLib/Channel.cs
@@ -33,7 +33,10 @@ namespace RaceLib
     {
         Analogue,
         DJIDigital,
-        HDZeroDigital
+        HDZeroDigital,
+        DJIO3Digital,
+        DJIO4Digital,
+        WalkSnailDigital,
     }
 
     public class Channel : BaseObject

--- a/RaceLib/Ext.cs
+++ b/RaceLib/Ext.cs
@@ -405,7 +405,7 @@ namespace RaceLib
                 Channel[] interferring = next.GetInterferringChannels(channels).ToArray();
                 if (interferring.Any())
                 {
-                    yield return interferring.ToArray();
+                    yield return interferring.OrderBy(r => r.Band).ToArray();
                     channels.RemoveAll(r => interferring.Contains(r));
                 }
             }

--- a/RaceLib/Ext.cs
+++ b/RaceLib/Ext.cs
@@ -349,6 +349,12 @@ namespace RaceLib
             {
                 case Band.DJIFPVHD:
                     return BandType.DJIDigital;
+                case Band.DJIO3:
+                    return BandType.DJIO3Digital;
+                case Band.DJIO4:
+                    return BandType.DJIO4Digital;
+                case Band.WalkSnail:
+                    return BandType.WalkSnailDigital;
                 case Band.HDZero:
                     return BandType.HDZeroDigital;
                 default:


### PR DESCRIPTION
Improve management of mixed Analog/HDZero/and multiple DJI revisions channels:

- Fix o3 and o4 being mixed with analog channels on redistribute or randomize channel
- Order channel lists inside each channel group by band
- Add prefix for O3 channels to tell them apart from vista channels