### PR TITLE
ArUco: ignore lost-signal frames on racing channels too (default off)

### DIFF
--- a/Timing/Aruco/ArucoMarkerDetector.cs
+++ b/Timing/Aruco/ArucoMarkerDetector.cs
@@ -188,6 +188,55 @@ namespace Timing.Aruco
             return results;
         }
 
+        /// <summary>
+        /// Measures how much contrast survives a heavy blur — the raspi4eyes signal-quality metric.
+        /// RF snow has no spatial correlation so blurring wipes out its contrast (ratio ~0),
+        /// while real video keeps its large-scale light/dark structure (ratio high, ~0.6-0.85).
+        /// A flat single-colour frame (black/blue screen) returns 0 (no signal).
+        /// Returns 1.0 (treat as valid video) on any failure so detection is never silently lost.
+        /// </summary>
+        public static double SignalRatio(byte[] bgra, int width, int height)
+        {
+            if (bgra == null || bgra.Length < width * height * 4) return 1.0;
+            try
+            {
+                using (Mat bgraMat = new Mat(height, width, MatType.CV_8UC4))
+                using (Mat gray = new Mat())
+                using (Mat small = new Mat())
+                {
+                    Marshal.Copy(bgra, 0, bgraMat.Data, bgra.Length);
+                    Cv2.CvtColor(bgraMat, gray, ColorConversionCodes.BGRA2GRAY);
+                    // Downscale to make the measurement cheap and to suppress per-pixel jitter.
+                    Cv2.Resize(gray, small, new OpenCvSharp.Size(80, 60));
+
+                    Cv2.MeanStdDev(small, out _, out Scalar stdRaw);
+                    double valRaw = stdRaw.Val0;
+                    // Almost no contrast at all => single colour (no signal / blue screen).
+                    if (valRaw < 3.0) return 0.0;
+
+                    using (Mat blurred = new Mat())
+                    {
+                        Cv2.GaussianBlur(small, blurred, new OpenCvSharp.Size(15, 15), 0);
+                        Cv2.MeanStdDev(blurred, out _, out Scalar stdBlur);
+                        return stdBlur.Val0 / valRaw;
+                    }
+                }
+            }
+            catch
+            {
+                return 1.0;
+            }
+        }
+
+        /// <summary>
+        /// Returns true when the BGRA frame looks like a lost signal — RF snow or a flat no-signal
+        /// screen — i.e. its <see cref="SignalRatio"/> is below <paramref name="threshold"/>.
+        /// </summary>
+        public static bool IsLostSignal(byte[] bgra, int width, int height, double threshold)
+        {
+            return SignalRatio(bgra, width, height) < threshold;
+        }
+
         private void DetectInto(Mat gray, List<MarkerDetection> into, DetectionSource source)
         {
             Point2f[][] corners;

--- a/Timing/Aruco/ArucoTimingSettings.cs
+++ b/Timing/Aruco/ArucoTimingSettings.cs
@@ -66,6 +66,16 @@ namespace Timing.Aruco
         [Description("Run ArUco detection for each channel in parallel (recommended for 4+ cores).")]
         public bool UseMultiThreadDetection { get; set; }
 
+        [Category("Detection")]
+        [DisplayName("Ignore Lost-Signal Frames")]
+        [Description("During a race, feed a black frame to the detector when a racing pilot's channel has lost signal (RF snow or a no-signal screen). Prevents the huge contour counts that cause CPU spikes and false detections. Only affects detection input, not the displayed video.")]
+        public bool IgnoreLostSignal { get; set; }
+
+        [Category("Detection")]
+        [DisplayName("Lost Signal Threshold")]
+        [Description("Signal ratio below which a frame is treated as lost signal (0.0 - 1.0). RF snow ~0.01-0.07, live video ~0.6-0.85. Lower = less aggressive. Only used when Ignore Lost-Signal Frames is enabled.")]
+        public float LostSignalThreshold { get; set; }
+
         [Category("Overlay")]
         [DisplayName("Show Marker Box")]
         [Description("Draw the detected marker outline on both live video and Replay recording.")]
@@ -87,6 +97,11 @@ namespace Timing.Aruco
         public bool ShowFps { get; set; }
 
         [Category("Overlay")]
+        [DisplayName("Show Signal Ratio")]
+        [Description("Draw each channel's live signal ratio and the threshold (measured/threshold) on its overlay. Red when below threshold (treated as lost signal). Useful for tuning Lost Signal Threshold.")]
+        public bool ShowSignalRatio { get; set; }
+
+        [Category("Overlay")]
         [DisplayName("Character Flip Vertical")]
         [Description("Render the overlay text (ID / size % / FPS) upside-down. Useful when the camera or display is mounted vertically inverted. Text position is unchanged; only the glyphs are flipped.")]
         public bool CharacterFlipVertical { get; set; }
@@ -101,10 +116,13 @@ namespace Timing.Aruco
             ErrorCorrectionRate = 0.6f;
             HybridDistanceThreshold = 20;
             UseMultiThreadDetection = true;
+            IgnoreLostSignal = false;
+            LostSignalThreshold = 0.4f;
             ShowMarkerBox = true;
             ShowMarkerId = true;
             ShowMarkerSizePercent = true;
             ShowFps = false;
+            ShowSignalRatio = false;
             CharacterFlipVertical = true;
         }
 

--- a/UI/Video/ArucoFrameOverlay.cs
+++ b/UI/Video/ArucoFrameOverlay.cs
@@ -32,6 +32,12 @@ namespace UI.Video
             public bool FlipY;
             /// <summary>Horizontal mirror applied when drawing into the detection RT.</summary>
             public bool MirrorX;
+
+            /// <summary>
+            /// Latest signal ratio for this channel (see ArucoMarkerDetector.SignalRatio).
+            /// NaN when not measured (e.g. unassigned channel) — the overlay then draws nothing.
+            /// </summary>
+            public double SignalRatio = double.NaN;
         }
 
         /// <summary>
@@ -71,7 +77,14 @@ namespace UI.Video
         public static volatile bool ShowId = true;
         public static volatile bool ShowSizePercent = true;
         public static volatile bool ShowFps = false;
+        public static volatile bool ShowSignalRatio = false;
         public static volatile bool Enabled = false;
+
+        /// <summary>
+        /// Lost-signal threshold (shared, from the reference ArUco settings), drawn alongside each
+        /// channel's measured signal ratio so "measured/threshold" reads like the FPS overlay.
+        /// </summary>
+        public static volatile float LostSignalThreshold = 0.4f;
 
         /// <summary>
         /// When true, overlay text (ID / size % / FPS) is rendered upside-down at the same on-screen
@@ -158,7 +171,7 @@ namespace UI.Video
         private static void OnBeforeFrame(ImageServer.FrameSource source, byte[] buffer)
         {
             if (!Enabled || buffer == null) return;
-            if (!(ShowBox || ShowId || ShowSizePercent || ShowFps)) return;
+            if (!(ShowBox || ShowId || ShowSizePercent || ShowFps || ShowSignalRatio)) return;
 
             int w = source.FrameWidth;
             int h = source.FrameHeight;
@@ -175,7 +188,7 @@ namespace UI.Video
                     if (entry?.Geometry == null) continue;
                     var active = CollectActive(entry, now);
                     bool hasMarkers = active != null && active.Count > 0;
-                    if (!hasMarkers && !ShowFps) continue;
+                    if (!hasMarkers && !ShowFps && !ShowSignalRatio) continue;
                     DrawInto(data, w, h, source.FrameFormat, entry.Geometry, active);
                 }
             }
@@ -188,7 +201,7 @@ namespace UI.Video
         private static void OnBeforeFramePtr(ImageServer.FrameSource source, IntPtr buffer, int length)
         {
             if (!Enabled || buffer == IntPtr.Zero) return;
-            if (!(ShowBox || ShowId || ShowSizePercent || ShowFps)) return;
+            if (!(ShowBox || ShowId || ShowSizePercent || ShowFps || ShowSignalRatio)) return;
 
             int w = source.FrameWidth;
             int h = source.FrameHeight;
@@ -201,7 +214,7 @@ namespace UI.Video
                 if (entry?.Geometry == null) continue;
                 var active = CollectActive(entry, now);
                 bool hasMarkers = active != null && active.Count > 0;
-                if (!hasMarkers && !ShowFps) continue;
+                if (!hasMarkers && !ShowFps && !ShowSignalRatio) continue;
                 DrawInto(buffer, w, h, source.FrameFormat, entry.Geometry, active);
             }
         }
@@ -253,6 +266,34 @@ namespace UI.Video
                         DrawOverlayText(mat, w, h, fpsText, fpsOrg,
                                         fontScale * 1.2, fpsColor, textThickness,
                                         outlineScale: fontScale * 1.2, outlineThickness: textThickness + 2);
+                    }
+
+                    // Signal-ratio readout: "measured/threshold" at the channel's centre-left,
+                    // mirroring the FPS overlay style. Red when below threshold (frame treated as
+                    // lost signal), else green. Skipped when this channel has no measurement (NaN).
+                    if (ShowSignalRatio && !double.IsNaN(cached.SignalRatio))
+                    {
+                        double thr = LostSignalThreshold;
+                        bool lostSignal = cached.SignalRatio < thr;
+                        string signalText = "S " + cached.SignalRatio.ToString("F2") + "/" + thr.ToString("F2");
+                        double nScale = fontScale * 1.2;
+                        int nThick = textThickness;
+
+                        OpenCvSharp.Size signalTextSize = Cv2.GetTextSize(
+                            signalText, HersheyFonts.HersheySimplex, nScale, nThick + 2, out _);
+                        double nxBase = cropX + 6;
+                        double nyBase = cropY + cropH / 2 + signalTextSize.Height / 2.0; // vertical centre, left side
+                        if (cached.MirrorX) nxBase = w - 1 - nxBase;
+                        if (cached.FlipY)   nyBase = h - 1 - nyBase;
+
+                        // red when lost signal, green when valid (channel-order aware).
+                        Scalar signalColor = format == SurfaceFormat.Color
+                            ? (lostSignal ? new Scalar(255, 60, 60, 255) : new Scalar(60, 255, 60, 255))   // RGBA
+                            : (lostSignal ? new Scalar(60, 60, 255, 255) : new Scalar(60, 255, 60, 255));  // BGRA
+                        var signalOrg = new Point((int)nxBase, (int)nyBase);
+                        DrawOverlayText(mat, w, h, signalText, signalOrg,
+                                        nScale, signalColor, nThick,
+                                        outlineScale: nScale, outlineThickness: nThick + 2);
                     }
 
                     if (detections == null) return;

--- a/UI/Video/ArucoTimingManager.cs
+++ b/UI/Video/ArucoTimingManager.cs
@@ -258,6 +258,13 @@ namespace UI.Video
                     double sharedEcRate = primarySettings?.ErrorCorrectionRate ?? 0.0;
                     int sharedHybridDist = primarySettings?.HybridDistanceThreshold ?? 0;
 
+                    // Ignore lost-signal frames on racing pilots' channels (shared from the reference).
+                    bool ignoreLostSignal = primarySettings?.IgnoreLostSignal ?? false;
+                    double lostSignalThreshold = primarySettings?.LostSignalThreshold ?? 0.4;
+                    bool showSignalRatio = primarySettings?.ShowSignalRatio ?? false;
+                    // Measure the ratio whenever we either act on it (ignore) or display it (overlay).
+                    bool measureSignal = ignoreLostSignal || showSignalRatio;
+
                     // Overlay display flags track the Primary's settings.
                     if (primarySettings != null)
                     {
@@ -265,6 +272,8 @@ namespace UI.Video
                         ArucoFrameOverlay.ShowId = primarySettings.ShowMarkerId;
                         ArucoFrameOverlay.ShowSizePercent = primarySettings.ShowMarkerSizePercent;
                         ArucoFrameOverlay.ShowFps = primarySettings.ShowFps;
+                        ArucoFrameOverlay.ShowSignalRatio = primarySettings.ShowSignalRatio;
+                        ArucoFrameOverlay.LostSignalThreshold = primarySettings.LostSignalThreshold;
                         ArucoFrameOverlay.FlipTextVertical = primarySettings.CharacterFlipVertical;
                     }
                     bool multiThread = primarySettings?.UseMultiThreadDetection ?? true;
@@ -280,6 +289,9 @@ namespace UI.Video
                     // Phase 1: collect BGRA buffers from each FrameNodeThumb sequentially
                     // (GetColorData can race with the UI draw thread; do it once up front).
                     var inputs = new (ChannelVideoNode cvn, byte[] bgra)[channelNodes.Length];
+                    // Per-channel signal ratio for the overlay; NaN = not measured.
+                    var channelSignal = new double[channelNodes.Length];
+                    Array.Fill(channelSignal, double.NaN);
                     for (int i = 0; i < channelNodes.Length; i++)
                     {
                         var cvn = channelNodes[i];
@@ -316,6 +328,20 @@ namespace UI.Video
                             bgra[k * 4 + 2] = p.R;
                             bgra[k * 4 + 3] = p.A;
                         }
+
+                        // Of the channels we still detect on (a racing pilot is registered), measure the
+                        // signal ratio when we either act on it (ignore) or display it (overlay).
+                        // Blank out any lost-signal frame so the detector never chews on snow. We
+                        // zero the buffer rather than skip detection so the timing system still receives a
+                        // "0 markers" report, consistent with the unassigned-channel path above.
+                        if (measureSignal)
+                        {
+                            double ratio = ArucoMarkerDetector.SignalRatio(bgra, FrameWidth, FrameHeight);
+                            channelSignal[i] = ratio;
+                            if (ignoreLostSignal && ratio < lostSignalThreshold)
+                                Array.Clear(bgra, 0, bgra.Length);
+                        }
+
                         inputs[i] = (cvn, bgra);
                     }
 
@@ -376,6 +402,7 @@ namespace UI.Video
                                 CropRelH = rsb.Height,
                                 FlipY = flipY,
                                 MirrorX = mirrorX,
+                                SignalRatio = channelSignal[ch],
                             };
                             // Key per-channel so multiple channels sharing one FrameSource
                             // (e.g. 2x2 capture) each keep their own crop cached.


### PR DESCRIPTION
## Background
In 89cc217, video on channels not assigned to the race is skipped for ArUco
detection (fed a black frame). The purpose is to prevent ArUco's detection rate
(FPS) from dropping when a channel with no race participant shows RF static —
the huge contour count from static spikes the detector's load.

## What this changes
However, even channels already assigned to the race can lose signal after a
crash or power loss. This commit also measures a per-channel **signal ratio** on
the remaining (racing) channels, and feeds only the frames judged to be
lost-signal to the detector as black frames. This keeps the detection rate up
even after a participating pilot crashes. It only affects detection input — the
displayed video is never changed.

(Channels not in the race remain handled by 89cc217 — they don't even need this
signal check, so that path is still the more efficient one.)

## Why this lives in the ArUco system, not the existing Static Detector
The repo already has a "Static Detector" in Profile Settings, so before adding
anything I looked at hooking into it rather than running a second system. They
turn out to be doing different jobs, and coupling them would make both worse —
so the lost-signal handling stays inside the ArUco detector:

1. **Different job.** The existing detector keys off *saturation + frame-diff* to
   decide "is there signal / is it moving" for crash-out (no-signal / stalled
   feeds), and it does that job well. But RF snow has a large frame-diff, so it
   reads more as "moving" — it is simply a different thing from a metric for *the
   spatial noise structure that explodes ArUco's contour count*. The ArUco path
   targets that structure directly (a blur-survival ratio).
2. **Dependency footprint.** The existing detector is pure managed C# running
   continuously on every channel for all users. The signal metric is OpenCV
   (native). Folding it into that always-on path would impose an OpenCV call on
   the majority who never use ArUco.
3. **Cadence.** The existing detector is tuned for second-scale decisions on the
   small thumbnail buffer; ArUco needs a per-frame decision on the full-resolution
   frame, which it already holds in its own loop — so measuring there is
   essentially free.
4. **Opposite tolerance — the real risk.** A brief burst of snow usually recovers
   within a second, and the existing detector is *deliberately* slow about it
   (multi-second windows + hysteresis) so a glitch never flips a pilot's crash-out
   state. ArUco needs the opposite: an instantaneous per-frame decision that
   resumes the moment the signal returns. Coupling them would either make
   crash-out flap on brief static, or slow ArUco's reaction and drop frames during
   recovery.

To keep the two clearly distinct, the new options are named around "lost signal"
rather than "static", avoiding any collision with the existing Static Detector.

## Why it's off by default
On setups where the receiver does not display static on no-signal (e.g. the
HDZero Event VRX), this processing is unnecessary (wasteful). It is therefore off
by default and can be toggled from the ArUco Timing Settings. The detection
threshold is configurable, and a per-channel overlay of the measured value is
provided for tuning.

## New settings (ArUco Timing Settings)
- **Ignore Lost-Signal Frames** (bool, default false): feed a black frame to the
  detector when a racing channel has lost signal
- **Lost Signal Threshold** (float, default 0.4): signal ratio below which a frame
  is treated as lost signal
- **Show Signal Ratio** (bool, default false): overlay each channel's
  measured/threshold (red = below threshold, green = above)

## How it works (4 steps)
1. Downscale the frame to 80×60 grayscale (cheap + suppresses per-pixel jitter)
2. Measure the standard deviation before blurring (raw contrast)
3. Heavily blur it (GaussianBlur 15×15) and measure the standard deviation again
4. Compute `ratio = blurred / raw`; below **Lost Signal Threshold** (default 0.4)
   → treated as lost signal

RF snow has no spatial correlation, so blurring wipes out its contrast
(ratio ≈ 0.01–0.07), while real video keeps its large-scale structure
(ratio ≈ 0.6–0.85). A flat single-colour frame (no signal) reads as 0.

The detection logic is based on @nkozawa's branch:
https://github.com/nkozawa/raspi4eyes