### PR TITLE
Fix results stage exports when displayed on several columns

### DIFF
--- a/UI/Nodes/Rounds/EventLapCountsNode.cs
+++ b/UI/Nodes/Rounds/EventLapCountsNode.cs
@@ -55,7 +55,7 @@ namespace UI.Nodes.Rounds
         {
             List<string[]> output = new List<string[]>();
 
-            foreach (PilotLapCountsNode pn in PilotNodes.OrderBy(pn => pn.Bounds.Y))
+            foreach (PilotLapCountsNode pn in PilotNodes.OrderBy(pn => pn.Bounds.X).ThenBy(pn => pn.Bounds.Y))
             {
                 List<string> line = new List<string>();
                 if (pn.Pilot != null)

--- a/UI/Nodes/Rounds/EventLapsTimesNode.cs
+++ b/UI/Nodes/Rounds/EventLapsTimesNode.cs
@@ -143,7 +143,7 @@ namespace UI.Nodes.Rounds
         {
             List<string[]> output = new List<string[]>();
             output.Add(new string[] { "Pilot", "Time" });
-            foreach (EventPilotTimeNode pn in PilotNodes.OrderBy(pn => pn.Bounds.Y))
+            foreach (EventPilotTimeNode pn in PilotNodes.OrderBy(pn => pn.Bounds.X).ThenBy(pn => pn.Bounds.Y))
             {
                 if (pn.Pilot != null)
                 {

--- a/UI/Nodes/Rounds/EventPackCountNode.cs
+++ b/UI/Nodes/Rounds/EventPackCountNode.cs
@@ -42,7 +42,7 @@ namespace UI.Nodes.Rounds
         {
             List<string[]> output = new List<string[]>();
 
-            foreach (PilotPackCountNode pn in PilotNodes.OrderBy(pn => pn.Bounds.Y))
+            foreach (PilotPackCountNode pn in PilotNodes.OrderBy(pn => pn.Bounds.X).ThenBy(pn => pn.Bounds.Y))
             {
                 List<string> line = new List<string>();
                 if (pn.Pilot != null)

--- a/UI/Nodes/Rounds/EventPointsNode.cs
+++ b/UI/Nodes/Rounds/EventPointsNode.cs
@@ -56,7 +56,7 @@ namespace UI.Nodes.Rounds
         public override string[][] MakeTable()
         {
             List<string[]> output = new List<string[]>();
-            foreach (PilotPointsNode pn in PilotNodes.OrderBy(pn => pn.Bounds.Y))
+            foreach (PilotPointsNode pn in PilotNodes.OrderBy(pn => pn.Bounds.X).ThenBy(pn => pn.Bounds.Y))
             {
                 List<string> line = new List<string>();
                 if (pn.Pilot != null)


### PR DESCRIPTION
Fixes an issue where results stages "Copy Pilots" will intertwine results from both columns when the results are shown split over several columns.