### PR TITLE
Fix HDZero/HDMI capture freeze: keep MF async read pump alive through transient glitches

### DIFF
--- a/WindowsMediaPlatform/MediaFoundation/MediaFoundationFrameSource.cs
+++ b/WindowsMediaPlatform/MediaFoundation/MediaFoundationFrameSource.cs
@@ -132,20 +132,88 @@ namespace WindowsMediaPlatform.MediaFoundation
 
         public virtual HResult OnReadSample(HResult hrStatus, int dwStreamIndex, MF_SOURCE_READER_FLAG dwStreamFlags, long timestep, IMFSample sample)
         {
-            HResult hr = hrStatus;
-
-            if (sample != null)
+            // This is the self-pumping async read loop: each callback must request the next
+            // sample, or frames stop forever. A live HDMI capture (e.g. an HDZero VRX feeding
+            // a capture card) routinely produces transient read errors and stream discontinuities
+            // when the signal briefly drops or renegotiates. Those must NOT kill the pump — if
+            // they do, no more frames arrive, the 10s frame watchdog fires and VideoManager does
+            // a full device teardown/re-open, which is the multi-second freeze users see. So we
+            // keep re-arming through transient issues and only hand off to a clean reconnect for
+            // genuinely terminal conditions. Nothing here may throw off the MF work-queue thread.
+            try
             {
-                hr = ProcessRaw(sample);
-            }
+                // Process whatever we got. A null sample (a stream tick / gap with no data) is
+                // normal during a brief signal loss and is not an error.
+                if (sample != null)
+                {
+                    try
+                    {
+                        ProcessRaw(sample);
+                    }
+                    catch (Exception e)
+                    {
+                        // A single bad/oversized frame must not tear down the capture loop.
+                        Logger.VideoLog.LogException(this, e);
+                    }
+                }
 
-            if (MFHelper.Succeeded(hrStatus) && State == States.Running)
-            {
+                if (State != States.Running)
+                {
+                    // Paused/stopped: don't re-arm. Unpause()/Start() restarts the pump.
+                    return HResult.S_OK;
+                }
+
+                // End-of-stream is terminal — let VideoManager reconnect from scratch.
+                if ((dwStreamFlags & MF_SOURCE_READER_FLAG.EndOfStream) != 0)
+                {
+                    Logger.VideoLog.Log(this, "OnReadSample EndOfStream - flagging for reconnect");
+                    Connected = false;
+                    return HResult.S_OK;
+                }
+
+                // A real format renegotiation (resolution / pixel-format change on the HDMI
+                // source) needs the transforms rebuilt for the new dimensions. Flag a clean
+                // reinit via VideoManager rather than reading on with mismatched processors.
+                if ((dwStreamFlags & (MF_SOURCE_READER_FLAG.CurrentMediaTypeChanged | MF_SOURCE_READER_FLAG.NativeMediaTypeChanged)) != 0)
+                {
+                    Logger.VideoLog.Log(this, "OnReadSample media type changed (flags=" + dwStreamFlags + ") - flagging for reinit");
+                    Connected = false;
+                    return HResult.S_OK;
+                }
+
+                // A transient read error or error flag (a brief HDMI dropout / glitch). Keep the
+                // pump alive so frames resume the instant the source recovers, instead of stalling
+                // until the watchdog forces a full teardown. Back off briefly so we don't hot-loop
+                // while the signal is genuinely absent — the watchdog still fires and reconnects
+                // if it never returns.
+                if (MFHelper.Failed(hrStatus) || (dwStreamFlags & MF_SOURCE_READER_FLAG.Error) != 0)
+                {
+                    Logger.VideoLog.Log(this, "OnReadSample transient read issue (hr=0x" + ((int)hrStatus).ToString("X8") + " flags=" + dwStreamFlags + ") - re-arming");
+                    Thread.Sleep(15);
+                }
+
                 // Ask for the next sample.
-                hr = readerAsync.ReadSample((int)MF_SOURCE_READER.FirstVideoStream, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
-                MFError.ThrowExceptionForHR(hr);
+                HResult hr = readerAsync.ReadSample((int)MF_SOURCE_READER.FirstVideoStream, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                if (MFHelper.Failed(hr))
+                {
+                    // Couldn't re-arm at all — hand off to VideoManager for a clean reconnect
+                    // rather than dying silently on the callback thread.
+                    Logger.VideoLog.Log(this, "OnReadSample ReadSample re-arm failed (hr=0x" + ((int)hr).ToString("X8") + ") - flagging for reconnect");
+                    Connected = false;
+                }
             }
-            MFHelper.SafeRelease(sample);
+            catch (Exception e)
+            {
+                // Never let an exception propagate out of the MF callback thread — that would
+                // silently kill the pump with no recovery. Fall back to a clean reconnect.
+                Logger.VideoLog.LogException(this, e);
+                Connected = false;
+            }
+            finally
+            {
+                MFHelper.SafeRelease(sample);
+            }
+
             return HResult.S_OK;
         }
 


### PR DESCRIPTION
## Problem

Live HDMI capture (notably **HDZero VRX → capture card**) intermittently **freezes the video in TrackSide for several seconds**. This regressed with the DirectShow→Media Foundation capture refactor — older builds did not exhibit it.

### Evidence (operator logs, build 2.76.4.871)

Capture device: *Live Gamer Ultra 2.1* (AVerMedia GC553 G2), 3840×2160 NV12.

```
19:39:52.001  VIDEOLOG  MediaFoundationCaptureFrameSource: Failed to read a frame after 10000ms.
19:39:54.315  VIDEOLOG  CleanUp  +  MFSinkWriterRecorder: StopRecording
19:39:54.374  VIDEOLOG  SetDevice (Live Gamer Ultra 2.1-Video ...)   <- full device re-open
```

Frames stalled, the 10s watchdog fired, and `VideoManager` did a full device `Stop/CleanUp/Start` — the visible freeze.

## Root cause

In `MediaFoundationFrameSource.OnReadSample` (the self-pumping async source-reader callback), the next `ReadSample` was re-armed **only** on a successful callback, and the re-arm itself `throw`s on failure:

```csharp
if (MFHelper.Succeeded(hrStatus) && State == States.Running)
{
    hr = readerAsync.ReadSample(...);
    MFError.ThrowExceptionForHR(hr);   // escapes the MF work-queue thread
}
```

`dwStreamFlags` is ignored entirely. A live HDMI source that briefly drops or renegotiates (exactly what HDZero VRX HDMI output does on signal loss / mode change) delivers a transient error callback or a stream flag — which permanently ends the pump. No more frames → 10s watchdog → full teardown. The old DirectShow / synchronous-poll path tolerated these transient glitches, which is why this only appears in newer builds.

## Fix

Harden `OnReadSample` so the pump self-heals and only hands off to a clean reconnect for genuinely terminal conditions:

- **Transient read error / `Error` flag** — log, brief back-off, **re-arm** so frames resume the moment the source recovers (no teardown).
- **Null sample / stream tick** — normal gap, keep pumping.
- **`EndOfStream`** — flag a clean reconnect.
- **`CurrentMediaTypeChanged` / `NativeMediaTypeChanged`** — flag a clean reinit so transforms rebuild for the new dimensions rather than reading on with mismatched buffers.
- **Re-arm `ReadSample` failure** — flag a clean reconnect instead of throwing.
- **Entire body guarded** — nothing escapes the MF callback thread; a single bad frame's `ProcessRaw` can't kill the loop.

The 10s watchdog + full reinit remains as the safety net for a genuine sustained (≥10s) signal loss. Capture resolution is **untouched** — 4K is unaffected (many clubs run 4K for stream quality).

## Testing status

⚠️ **Not yet compiled or run** — authored against the confirmed APIs (`MF_SOURCE_READER_FLAG` values, `MFHelper`, `Logger.VideoLog` overloads, `Connected` accessibility) but the project targets `net9.0-windows` and needs a **Windows build + smoke test against a live HDMI capture** before merge. Expected observable change: logs show `OnReadSample transient read issue ... re-arming` where they previously showed `Failed to read a frame after 10000ms` + `SetDevice`.

Single-file change: `WindowsMediaPlatform/MediaFoundation/MediaFoundationFrameSource.cs`.