### PR TITLE
Add ExpressLRS Backpack race control

### DIFF
--- a/Timing/ELRS/ELRSSettings.cs
+++ b/Timing/ELRS/ELRSSettings.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+
+namespace Timing.ELRS
+{
+    public class ELRSSettings : TimingSystemSettings
+    {
+        [Category("VRXC Connection")]
+        [Description("Serial port name (e.g., COM3, /dev/ttyUSB0) connected to ESP32 running VRXC/ELRS Backpack firmware")]
+        [DisplayName("Serial Port")]
+        public string ComPort { get; set; }
+
+        [Category("VRXC Connection")]
+        [Description("Serial baud rate (default: 460800 for ELRS/MSP)")]
+        public int BaudRate { get; set; }
+
+        [Category("Race Control")]
+        [Description("Minimum time between race start/stop commands in milliseconds (debounce)")]
+        public int DebounceMs { get; set; }
+
+        public ELRSSettings()
+        {
+            Role = TimingSystemRole.Split;
+            ComPort = "None";
+            BaudRate = 460800;
+            DebounceMs = 500;
+        }
+
+        public override string ToString()
+        {
+            return $"ELRS Backpack ({ComPort})";
+        }
+    }
+}

--- a/Timing/ELRS/ELRSTimingSystem.cs
+++ b/Timing/ELRS/ELRSTimingSystem.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using Tools;
+
+namespace Timing.ELRS
+{
+    /// <summary>
+    /// Receives race start/stop commands from an ExpressLRS timer backpack.
+    /// The device controls race state only; lap detections still come from a
+    /// separately configured primary timing system.
+    /// </summary>
+    public class ELRSTimingSystem : IRaceControlTimingSystem
+    {
+        private ELRSSettings settings;
+        private readonly VRXCProtocol protocol;
+        private DateTime lastStartTriggerTime;
+        private DateTime lastStopTriggerTime;
+        private string backpackVersion;
+
+        public TimingSystemType Type => TimingSystemType.Other;
+        public string Name => "ELRS";
+        public bool Connected => protocol.IsConnected;
+        public int MaxPilots => 0;
+
+        public TimingSystemSettings Settings
+        {
+            get => settings;
+            set => settings = value as ELRSSettings ?? new ELRSSettings();
+        }
+
+        // Required by ITimingSystem. Race-control systems are excluded from the
+        // detection pipeline by TimingSystemManager, so these events are unused.
+        public event DetectionEventDelegate OnDetectionEvent;
+        public event MarshallEventDelegate OnMarshallEvent;
+
+        public event Action OnRaceStartRequest;
+        public event Action OnRaceStopRequest;
+
+        public IEnumerable<StatusItem> Status
+        {
+            get
+            {
+                yield return new StatusItem
+                {
+                    StatusOK = Connected,
+                    Value = Connected ? $"Connected ({settings.ComPort})" : "Disconnected"
+                };
+
+                if (Connected && !string.IsNullOrWhiteSpace(backpackVersion))
+                {
+                    yield return new StatusItem
+                    {
+                        StatusOK = true,
+                        Value = $"Firmware {backpackVersion}"
+                    };
+                }
+
+                if (Connected)
+                {
+                    yield return new StatusItem
+                    {
+                        StatusOK = true,
+                        Value = "Race control ready"
+                    };
+                }
+            }
+        }
+
+        public ELRSTimingSystem()
+        {
+            settings = new ELRSSettings();
+            protocol = new VRXCProtocol();
+            lastStartTriggerTime = DateTime.MinValue;
+            lastStopTriggerTime = DateTime.MinValue;
+
+            protocol.OnStartRaceCommand += HandleStartRaceCommand;
+            protocol.OnStopRaceCommand += HandleStopRaceCommand;
+            protocol.OnBackpackVersion += HandleBackpackVersion;
+            protocol.OnError += HandleError;
+        }
+
+        public bool Connect()
+        {
+            if (string.IsNullOrWhiteSpace(settings.ComPort) || settings.ComPort == "None")
+            {
+                Logger.TimingLog.Log(this, "Connection failed", "No serial port configured", Logger.LogType.Error);
+                return false;
+            }
+
+            Logger.TimingLog.Log(this, "Connecting", settings.ComPort, Logger.LogType.Notice);
+            bool connected = protocol.Connect(settings.ComPort, settings.BaudRate);
+
+            if (connected)
+            {
+                Logger.TimingLog.Log(this, "Connected", $"{settings.ComPort} @ {settings.BaudRate} baud", Logger.LogType.Notice);
+            }
+
+            return connected;
+        }
+
+        public bool Disconnect()
+        {
+            protocol.Disconnect();
+            backpackVersion = null;
+            return true;
+        }
+
+        public bool SetListeningFrequencies(IEnumerable<ListeningFrequency> newFrequencies)
+        {
+            return true;
+        }
+
+        public bool StartDetection(ref DateTime time, StartMetaData raceMetaData)
+        {
+            return Connected;
+        }
+
+        public bool EndDetection(EndDetectionType type)
+        {
+            return true;
+        }
+
+        private bool IsDebounced(ref DateTime lastTriggerTime)
+        {
+            DateTime now = DateTime.UtcNow;
+            int debounceMs = Math.Max(0, settings.DebounceMs);
+
+            if ((now - lastTriggerTime).TotalMilliseconds < debounceMs)
+            {
+                return true;
+            }
+
+            lastTriggerTime = now;
+            return false;
+        }
+
+        private void HandleStartRaceCommand()
+        {
+            if (IsDebounced(ref lastStartTriggerTime))
+            {
+                Logger.TimingLog.Log(this, "Debounce", "Start command ignored", Logger.LogType.Notice);
+                return;
+            }
+
+            Logger.TimingLog.Log(this, "ELRS command", "Start race", Logger.LogType.Notice);
+            OnRaceStartRequest?.Invoke();
+        }
+
+        private void HandleStopRaceCommand()
+        {
+            if (IsDebounced(ref lastStopTriggerTime))
+            {
+                Logger.TimingLog.Log(this, "Debounce", "Stop command ignored", Logger.LogType.Notice);
+                return;
+            }
+
+            Logger.TimingLog.Log(this, "ELRS command", "Stop race", Logger.LogType.Notice);
+            OnRaceStopRequest?.Invoke();
+        }
+
+        private void HandleBackpackVersion(string version)
+        {
+            backpackVersion = version;
+            Logger.TimingLog.Log(this, "Backpack version", version, Logger.LogType.Notice);
+        }
+
+        private void HandleError(string error)
+        {
+            Logger.TimingLog.Log(this, "ELRS error", error, Logger.LogType.Error);
+        }
+
+        public void Dispose()
+        {
+            protocol.OnStartRaceCommand -= HandleStartRaceCommand;
+            protocol.OnStopRaceCommand -= HandleStopRaceCommand;
+            protocol.OnBackpackVersion -= HandleBackpackVersion;
+            protocol.OnError -= HandleError;
+            protocol.Dispose();
+        }
+    }
+}

--- a/Timing/ELRS/README.md
+++ b/Timing/ELRS/README.md
@@ -1,0 +1,55 @@
+# ExpressLRS Backpack race control
+
+This integration lets a race director start and stop FPV Trackside races with
+the `DVR Rec` switch configured in an ExpressLRS transmitter backpack. It uses
+the same MSP v2 messages as the RotorHazard
+[VRxC ELRS plugin](https://github.com/i-am-grub/vrxc_elrs).
+
+The backpack is a race-control accessory, not a lap timer. Configure a primary
+timing system such as RotorHazard, then add **ELRS Backpack (Race Control)** in
+Trackside's timing settings.
+
+## Setup
+
+1. Flash an ESP32/ESP8266 with the ExpressLRS `Race Timer` backpack target.
+   Backpack firmware 1.5.0 or newer is recommended by the VRxC ELRS project.
+2. Configure the backpack bind phrase and the transmitter's `DVR Rec` AUX
+   channel according to the
+   [VRxC ELRS race-control guide](https://github.com/i-am-grub/vrxc_elrs#control-the-race-from-the-race-directors-transmitter).
+3. Connect the timer backpack to the Trackside computer over USB.
+4. In Trackside timing settings, either:
+   - select **Scan Systems** and add the detected ELRS Backpack, or
+   - add **ELRS Backpack (Race Control)** and choose its serial port.
+5. Keep the baud rate at `460800` unless the backpack firmware is configured
+   differently.
+
+The start command follows Trackside's normal start-button path, including video
+checks, announcements, and configured start delay. The stop command follows the
+normal stop-button path, including cancellation of a race that is still staging.
+
+## Protocol
+
+Communication uses MSP v2 over an 8-N-1 serial connection:
+
+- `MSP_ELRS_GET_BACKPACK_VERSION` (`0x0010`) verifies the selected device.
+- `MSP_ELRS_BACKPACK_SET_RECORDING_STATE` (`0x0305`) carries race control:
+  - `0x01`: start race
+  - `0x00`: stop race
+- Packets use CRC-8/DVB-S2 with polynomial `0xD5`.
+
+Trackside validates the version response and packet CRC before accepting a
+device or command. The debounce setting suppresses repeated switch messages.
+
+## Hardware verification
+
+Automated builds can verify the parser and integration compile, but final
+verification requires a timer backpack and transmitter:
+
+1. Confirm the ELRS status changes to `Race control ready`.
+2. Select a race and toggle `DVR Rec` on; Trackside should enter its normal
+   staging/start sequence once.
+3. Toggle `DVR Rec` off while staging and while racing; Trackside should cancel
+   staging or stop the race through the normal UI workflow.
+
+If the device does not connect, verify the data-capable USB cable, serial port,
+460800 baud setting, backpack target, and bind phrase.

--- a/Timing/ELRS/VRXCProtocol.cs
+++ b/Timing/ELRS/VRXCProtocol.cs
@@ -1,0 +1,492 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Ports;
+using System.Text;
+using System.Threading;
+
+namespace Timing.ELRS
+{
+    /// <summary>
+    /// MSP v2 serial transport used by ExpressLRS timer backpacks.
+    /// </summary>
+    public sealed class VRXCProtocol : IDisposable
+    {
+        private const byte HeaderDollar = (byte)'$';
+        private const byte HeaderX = (byte)'X';
+        private const byte PacketCommand = (byte)'<';
+        private const byte PacketResponse = (byte)'>';
+        private const int HeaderLength = 8;
+        private const int MaxPayloadLength = 1024;
+
+        private const ushort SetRecordingState = 0x0305;
+        private const ushort GetBackpackVersion = 0x0010;
+
+        private const byte RecordingStopped = 0x00;
+        private const byte RecordingStarted = 0x01;
+
+        private readonly object connectionLock = new object();
+        private readonly object receiveLock = new object();
+        private readonly List<byte> receiveBuffer = new List<byte>();
+
+        private SerialPort serialPort;
+        private Thread readThread;
+        private volatile bool running;
+
+        public event Action OnStartRaceCommand;
+        public event Action OnStopRaceCommand;
+        public event Action<string> OnBackpackVersion;
+        public event Action<string> OnError;
+
+        public bool IsConnected
+        {
+            get
+            {
+                lock (connectionLock)
+                {
+                    return serialPort?.IsOpen == true;
+                }
+            }
+        }
+
+        public bool Connect(string portName, int baudRate = 460800)
+        {
+            Disconnect();
+
+            SerialPort candidate = null;
+            try
+            {
+                candidate = CreateSerialPort(portName, baudRate);
+                candidate.Open();
+
+                if (!TryHandshake(candidate, out string version))
+                {
+                    OnError?.Invoke($"No ELRS Backpack response on {portName}; check the port and firmware");
+                    candidate.Dispose();
+                    return false;
+                }
+
+                lock (receiveLock)
+                {
+                    receiveBuffer.Clear();
+                }
+
+                lock (connectionLock)
+                {
+                    serialPort = candidate;
+                    running = true;
+                    readThread = new Thread(() => ReadLoop(candidate))
+                    {
+                        IsBackground = true,
+                        Name = "ELRS Backpack Reader"
+                    };
+                    readThread.Start();
+                }
+
+                OnBackpackVersion?.Invoke(version);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                running = false;
+                try
+                {
+                    candidate?.Dispose();
+                }
+                catch
+                {
+                }
+
+                OnError?.Invoke($"Failed to connect to {portName}: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns the first serial port that answers a validated backpack version request.
+        /// </summary>
+        public static string DetectPort(int baudRate = 460800)
+        {
+            string[] avoidedPorts = { "COM1", "/dev/ttyAMA0", "/dev/ttyAMA10" };
+            string[] portNames;
+
+            try
+            {
+                portNames = SerialPort.GetPortNames();
+            }
+            catch
+            {
+                return null;
+            }
+
+            foreach (string portName in portNames)
+            {
+                if (Array.Exists(avoidedPorts, value => value.Equals(portName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    using (SerialPort candidate = CreateSerialPort(portName, baudRate))
+                    {
+                        candidate.Open();
+                        if (TryHandshake(candidate, out _))
+                        {
+                            return portName;
+                        }
+                    }
+                }
+                catch
+                {
+                    // Ports in use by another device are expected during a scan.
+                }
+            }
+
+            return null;
+        }
+
+        public void Disconnect()
+        {
+            SerialPort portToClose;
+            Thread threadToJoin;
+
+            lock (connectionLock)
+            {
+                running = false;
+                portToClose = serialPort;
+                threadToJoin = readThread;
+                serialPort = null;
+                readThread = null;
+            }
+
+            try
+            {
+                portToClose?.Close();
+            }
+            catch
+            {
+            }
+
+            if (threadToJoin != null && threadToJoin != Thread.CurrentThread)
+            {
+                threadToJoin.Join(1000);
+            }
+
+            try
+            {
+                portToClose?.Dispose();
+            }
+            catch
+            {
+            }
+
+            lock (receiveLock)
+            {
+                receiveBuffer.Clear();
+            }
+        }
+
+        private static SerialPort CreateSerialPort(string portName, int baudRate)
+        {
+            return new SerialPort(portName, baudRate, Parity.None, 8, StopBits.One)
+            {
+                ReadTimeout = 250,
+                WriteTimeout = 1000
+            };
+        }
+
+        private static bool TryHandshake(SerialPort port, out string version)
+        {
+            version = null;
+
+            Thread.Sleep(200);
+            port.DiscardInBuffer();
+
+            byte[] request = BuildPacket(PacketCommand, GetBackpackVersion, Array.Empty<byte>());
+            port.Write(request, 0, request.Length);
+
+            DateTime deadline = DateTime.UtcNow.AddMilliseconds(1500);
+            List<byte> buffer = new List<byte>();
+
+            while (DateTime.UtcNow < deadline)
+            {
+                int available = port.BytesToRead;
+                if (available == 0)
+                {
+                    Thread.Sleep(20);
+                    continue;
+                }
+
+                byte[] incoming = new byte[available];
+                int read = port.Read(incoming, 0, incoming.Length);
+                for (int i = 0; i < read; i++)
+                {
+                    buffer.Add(incoming[i]);
+                }
+
+                List<MSPPacket> packets = ExtractPackets(buffer, null);
+                foreach (MSPPacket packet in packets)
+                {
+                    if (packet.Type == PacketResponse && packet.Function == GetBackpackVersion)
+                    {
+                        version = DecodeVersion(packet.Payload);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void ReadLoop(SerialPort port)
+        {
+            byte[] incoming = new byte[256];
+
+            try
+            {
+                while (running)
+                {
+                    try
+                    {
+                        int read = port.Read(incoming, 0, incoming.Length);
+                        if (read > 0)
+                        {
+                            ProcessIncoming(incoming, read);
+                        }
+                    }
+                    catch (TimeoutException)
+                    {
+                        // A short timeout lets Disconnect stop this thread promptly.
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (running)
+                {
+                    OnError?.Invoke($"Serial read failed: {ex.Message}");
+                    MarkConnectionLost(port);
+                }
+            }
+        }
+
+        private void MarkConnectionLost(SerialPort failedPort)
+        {
+            lock (connectionLock)
+            {
+                if (!ReferenceEquals(serialPort, failedPort))
+                {
+                    return;
+                }
+
+                running = false;
+                serialPort = null;
+                readThread = null;
+            }
+
+            try
+            {
+                failedPort.Dispose();
+            }
+            catch
+            {
+            }
+        }
+
+        private void ProcessIncoming(byte[] incoming, int count)
+        {
+            List<string> errors = new List<string>();
+            List<MSPPacket> packets;
+
+            lock (receiveLock)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    receiveBuffer.Add(incoming[i]);
+                }
+
+                packets = ExtractPackets(receiveBuffer, errors);
+            }
+
+            foreach (string error in errors)
+            {
+                OnError?.Invoke(error);
+            }
+
+            foreach (MSPPacket packet in packets)
+            {
+                ProcessPacket(packet);
+            }
+        }
+
+        private static List<MSPPacket> ExtractPackets(List<byte> buffer, List<string> errors)
+        {
+            List<MSPPacket> packets = new List<MSPPacket>();
+
+            while (buffer.Count >= 2)
+            {
+                int headerIndex = FindHeader(buffer);
+                if (headerIndex < 0)
+                {
+                    bool keepDollar = buffer[buffer.Count - 1] == HeaderDollar;
+                    buffer.Clear();
+                    if (keepDollar)
+                    {
+                        buffer.Add(HeaderDollar);
+                    }
+                    break;
+                }
+
+                if (headerIndex > 0)
+                {
+                    buffer.RemoveRange(0, headerIndex);
+                }
+
+                if (buffer.Count < HeaderLength)
+                {
+                    break;
+                }
+
+                byte type = buffer[2];
+                if (type != PacketCommand && type != PacketResponse)
+                {
+                    buffer.RemoveAt(0);
+                    continue;
+                }
+
+                ushort function = (ushort)(buffer[4] | (buffer[5] << 8));
+                ushort payloadLength = (ushort)(buffer[6] | (buffer[7] << 8));
+                if (payloadLength > MaxPayloadLength)
+                {
+                    errors?.Add($"Ignoring MSP packet with invalid payload length {payloadLength}");
+                    buffer.RemoveAt(0);
+                    continue;
+                }
+
+                int packetLength = HeaderLength + payloadLength + 1;
+                if (buffer.Count < packetLength)
+                {
+                    break;
+                }
+
+                byte expectedCRC = CalculateCRC(buffer, 3, HeaderLength - 3 + payloadLength);
+                byte receivedCRC = buffer[packetLength - 1];
+                if (expectedCRC != receivedCRC)
+                {
+                    errors?.Add($"Ignoring MSP packet with invalid CRC (expected 0x{expectedCRC:X2}, received 0x{receivedCRC:X2})");
+                    buffer.RemoveAt(0);
+                    continue;
+                }
+
+                byte[] payload = new byte[payloadLength];
+                if (payloadLength > 0)
+                {
+                    buffer.CopyTo(HeaderLength, payload, 0, payloadLength);
+                }
+
+                packets.Add(new MSPPacket(type, function, payload));
+                buffer.RemoveRange(0, packetLength);
+            }
+
+            return packets;
+        }
+
+        private static int FindHeader(List<byte> buffer)
+        {
+            for (int i = 0; i < buffer.Count - 1; i++)
+            {
+                if (buffer[i] == HeaderDollar && buffer[i + 1] == HeaderX)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private void ProcessPacket(MSPPacket packet)
+        {
+            if (packet.Type == PacketCommand && packet.Function == SetRecordingState && packet.Payload.Length > 0)
+            {
+                if (packet.Payload[0] == RecordingStarted)
+                {
+                    OnStartRaceCommand?.Invoke();
+                }
+                else if (packet.Payload[0] == RecordingStopped)
+                {
+                    OnStopRaceCommand?.Invoke();
+                }
+            }
+            else if (packet.Type == PacketResponse && packet.Function == GetBackpackVersion)
+            {
+                OnBackpackVersion?.Invoke(DecodeVersion(packet.Payload));
+            }
+        }
+
+        private static string DecodeVersion(byte[] payload)
+        {
+            int length = Array.IndexOf(payload, (byte)0);
+            if (length < 0)
+            {
+                length = payload.Length;
+            }
+
+            return Encoding.UTF8.GetString(payload, 0, length);
+        }
+
+        private static byte[] BuildPacket(byte type, ushort function, byte[] payload)
+        {
+            payload ??= Array.Empty<byte>();
+            byte[] packet = new byte[HeaderLength + payload.Length + 1];
+
+            packet[0] = HeaderDollar;
+            packet[1] = HeaderX;
+            packet[2] = type;
+            packet[3] = 0;
+            packet[4] = (byte)(function & 0xFF);
+            packet[5] = (byte)(function >> 8);
+            packet[6] = (byte)(payload.Length & 0xFF);
+            packet[7] = (byte)(payload.Length >> 8);
+            Array.Copy(payload, 0, packet, HeaderLength, payload.Length);
+            packet[packet.Length - 1] = CalculateCRC(packet, 3, HeaderLength - 3 + payload.Length);
+
+            return packet;
+        }
+
+        private static byte CalculateCRC(IList<byte> data, int start, int length)
+        {
+            byte crc = 0;
+            for (int i = start; i < start + length; i++)
+            {
+                crc ^= data[i];
+                for (int bit = 0; bit < 8; bit++)
+                {
+                    crc = (crc & 0x80) != 0
+                        ? (byte)((crc << 1) ^ 0xD5)
+                        : (byte)(crc << 1);
+                }
+            }
+
+            return crc;
+        }
+
+        public void Dispose()
+        {
+            Disconnect();
+        }
+
+        private sealed class MSPPacket
+        {
+            public byte Type { get; }
+            public ushort Function { get; }
+            public byte[] Payload { get; }
+
+            public MSPPacket(byte type, ushort function, byte[] payload)
+            {
+                Type = type;
+                Function = function;
+                Payload = payload;
+            }
+        }
+    }
+}

--- a/Timing/ITimingSystem.cs
+++ b/Timing/ITimingSystem.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Timing.Chorus;
+using Timing.ELRS;
 using Timing.ImmersionRC;
 using Timing.RotorHazard;
 using Timing.Velocidrone;
@@ -148,6 +149,17 @@ namespace Timing
         string Name { get; }
     }
 
+    /// <summary>
+    /// Optional capability for devices that control race state but do not record laps.
+    /// Race-control systems are connected and displayed like timing systems, but are
+    /// excluded from the primary/split detection pipeline.
+    /// </summary>
+    public interface IRaceControlTimingSystem : ITimingSystem
+    {
+        event Action OnRaceStartRequest;
+        event Action OnRaceStopRequest;
+    }
+
     public struct StatusItem
     {
         public string Value { get; set; }
@@ -155,6 +167,7 @@ namespace Timing
     }
 
     [XmlInclude(typeof(DummySettings))]
+    [XmlInclude(typeof(ELRSSettings))]
     [XmlInclude(typeof(LapRFSettings))]
     [XmlInclude(typeof(LapRFSettingsUSB))]
     [XmlInclude(typeof(LapRFSettingsEthernet))]
@@ -245,5 +258,4 @@ namespace Timing
         public TimeSpan RaceTime { get; set; }
     }
 }
-
 

--- a/Timing/ImmersionRC/LapRFTimingUSB.cs
+++ b/Timing/ImmersionRC/LapRFTimingUSB.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LapRF;
+using System;
 using System.Collections.Generic;
 using System.IO.Ports;
 using System.Linq;
@@ -16,6 +17,90 @@ namespace Timing.ImmersionRC
         {
             timeoutSeconds = 30;
             comPort = null;
+        }
+
+        // Probes serial ports for a LapRF puck by sending a real RTC_TIME request and
+        // waiting for a validly-CRC'd response - same request the normal Connect() flow uses.
+        public static string DetectPort()
+        {
+            string[] avoidedPorts = { "COM1", "/dev/ttyAMA0", "/dev/ttyAMA10" };
+
+            string[] portNames;
+            try
+            {
+                portNames = SerialPort.GetPortNames();
+            }
+            catch
+            {
+                return null;
+            }
+
+            foreach (string portName in portNames)
+            {
+                if (Array.Exists(avoidedPorts, value => value.Equals(portName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+
+                if (TryProbe(portName))
+                {
+                    return portName;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool TryProbe(string portName)
+        {
+            SerialPort candidate = null;
+            try
+            {
+                candidate = new SerialPort(portName, 115200, Parity.None, 8, StopBits.One)
+                {
+                    RtsEnable = true,
+                    DtrEnable = true,
+                    ReadTimeout = 500,
+                    WriteTimeout = 1000
+                };
+                candidate.Open();
+
+                LapRFProtocol probe = new LapRFProtocol();
+                bool gotResponse = false;
+                probe.OnRTC += (rtcTime) => { gotResponse = true; };
+
+                byte[] request = probe.requestRTCTime().ToArray();
+                candidate.Write(request, 0, request.Length);
+
+                byte[] buffer = new byte[256];
+                DateTime deadline = DateTime.UtcNow.AddMilliseconds(2000);
+                while (!gotResponse && DateTime.UtcNow < deadline)
+                {
+                    try
+                    {
+                        int read = candidate.Read(buffer, 0, buffer.Length);
+                        if (read > 0)
+                        {
+                            probe.processBytes(buffer, read);
+                        }
+                    }
+                    catch (TimeoutException)
+                    {
+                        // No bytes yet - keep polling until the deadline.
+                    }
+                }
+
+                return gotResponse;
+            }
+            catch
+            {
+                // Ports in use by another device, or not a LapRF, are expected during a scan.
+                return false;
+            }
+            finally
+            {
+                candidate?.Dispose();
+            }
         }
 
         public override bool Connect()

--- a/Timing/TimingSystemManager.cs
+++ b/Timing/TimingSystemManager.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Timers;
 using Timing.Aruco;
 using Timing.Chorus;
+using Timing.ELRS;
 using Timing.ImmersionRC;
 using Timing.RotorHazard;
 using Timing.Velocidrone;
@@ -35,14 +36,26 @@ namespace Timing
         public event TimingSystemDetectionEventDelegate DetectionEvent;
         public event MarshallEventDelegate MarshallEvent;
 
+        public event Action RaceStartRequest;
+        public event Action RaceStopRequest;
+
         public ITimingSystem[] PrimeSystems { get; private set; }
         public ITimingSystem[] SplitSystems { get; private set; }
+        public IRaceControlTimingSystem[] RaceControlSystems { get; private set; }
 
         public IEnumerable<ITimingSystem> TimingSystems
         {
             get
             {
                 return PrimeSystems.Union(SplitSystems);
+            }
+        }
+
+        public IEnumerable<ITimingSystem> AllSystems
+        {
+            get
+            {
+                return TimingSystems.Union(RaceControlSystems.Cast<ITimingSystem>());
             }
         }
 
@@ -106,6 +119,7 @@ namespace Timing
         {
             PrimeSystems = new ITimingSystem[0];
             SplitSystems = new ITimingSystem[0];
+            RaceControlSystems = new IRaceControlTimingSystem[0];
             LastListeningFrequencies = new ListeningFrequency[0];
 
             InitialiseTimingSystems(profile);
@@ -116,12 +130,13 @@ namespace Timing
         {
             Logger.TimingLog.LogCall(this);
 
-            foreach (ITimingSystem timingSystem in TimingSystems)
+            foreach (ITimingSystem timingSystem in AllSystems)
             {
                 timingSystem.Dispose();
             }
             PrimeSystems = new ITimingSystem[0];
             SplitSystems = new ITimingSystem[0];
+            RaceControlSystems = new IRaceControlTimingSystem[0];
 
             HasSpectrumAnalyser = false;
         }
@@ -130,7 +145,7 @@ namespace Timing
         {
             Logger.TimingLog.LogCall(this);
 
-            if (TimingSystemCount > 0)
+            if (AllSystems.Any())
             {
                 ClearTimingSystems();
             }
@@ -139,7 +154,9 @@ namespace Timing
 
             TimingSystemsSettings = TimingSystemSettings.Read(profile);
 
-            ITimingSystem[] timingSystems = CreateTimingSystems().ToArray();
+            ITimingSystem[] allSystems = CreateTimingSystems().ToArray();
+            RaceControlSystems = allSystems.OfType<IRaceControlTimingSystem>().ToArray();
+            ITimingSystem[] timingSystems = allSystems.Except(RaceControlSystems.Cast<ITimingSystem>()).ToArray();
 
             foreach (ITimingSystem timingSystem in timingSystems)
             {
@@ -150,6 +167,12 @@ namespace Timing
                 {
                     HasSpectrumAnalyser = true;
                 }
+            }
+
+            foreach (IRaceControlTimingSystem raceControlSystem in RaceControlSystems)
+            {
+                raceControlSystem.OnRaceStartRequest += () => RaceStartRequest?.Invoke();
+                raceControlSystem.OnRaceStopRequest += () => RaceStopRequest?.Invoke();
             }
 
             if (timingSystems.Length > 1)
@@ -184,6 +207,9 @@ namespace Timing
 
                 else if (settings is DummySettings)
                     timingSystem = new DummyTimingSystem();
+
+                else if (settings is ELRSSettings)
+                    timingSystem = new ELRSTimingSystem();
 
                 else if (settings is RotorHazardSettings)
                     timingSystem = new RotorHazardTimingSystem();
@@ -239,22 +265,25 @@ namespace Timing
                         Thread.Sleep(100);
                     }
 
-                    if (PrimeSystems == null || !PrimeSystems.Any() || disposing)
+                    if (!AllSystems.Any() || disposing)
                         continue;
 
                     int newlyConnected = 0;
 
-                    foreach (ITimingSystem timingSystem in TimingSystems)
+                    foreach (ITimingSystem timingSystem in AllSystems)
                     {
                         if (!timingSystem.Connected && !disposing)
                         {
                             if (timingSystem.Connect())
                             {
-                                newlyConnected++;
+                                if (!(timingSystem is IRaceControlTimingSystem))
+                                {
+                                    newlyConnected++;
+                                    lastLoopState = true;
+                                }
                                 Logger.TimingLog.Log(this, "Connected", timingSystem, Logger.LogType.Notice);
-                                lastLoopState = true;
 
-                                if (!detectionRunning)
+                                if (!detectionRunning && !(timingSystem is IRaceControlTimingSystem))
                                 {
                                     timingSystem.EndDetection(EndDetectionType.Normal);
                                 }
@@ -396,7 +425,7 @@ namespace Timing
         public void Disconnect()
         {
             OnDataSent?.Invoke();
-            foreach (ITimingSystem timingSystem in TimingSystems)
+            foreach (ITimingSystem timingSystem in AllSystems)
             {
                 try
                 {

--- a/UI/EventLayer.cs
+++ b/UI/EventLayer.cs
@@ -150,6 +150,27 @@ namespace UI
                 SoundManager.TimingSystemDisconnected();
             };
 
+            EventManager.RaceManager.TimingSystemManager.RaceStartRequest += () =>
+            {
+                PlatformTools.Invoke(() =>
+                {
+                    Logger.UI.Log(this, "ELRS race control", "Start requested", Logger.LogType.Notice);
+                    StartRaceWithVideoCheck();
+                });
+            };
+
+            EventManager.RaceManager.TimingSystemManager.RaceStopRequest += () =>
+            {
+                PlatformTools.Invoke(() =>
+                {
+                    Logger.UI.Log(this, "ELRS race control", "Stop requested", Logger.LogType.Notice);
+                    if (EventManager.RaceManager.RaceRunning || EventManager.RaceManager.PreRaceStartDelay)
+                    {
+                        StopRace();
+                    }
+                });
+            };
+
             EventManager.RaceManager.OnRaceTimeRemaining += (r, t) =>
             {
                 SoundManager.TimeRemaining(r, t);

--- a/UI/Nodes/SystemStatusNode.cs
+++ b/UI/Nodes/SystemStatusNode.cs
@@ -38,7 +38,7 @@ namespace UI.Nodes
 
             AddChild(new FrameRateStatusNode());
 
-            foreach (ITimingSystem timingSystem in timingSystemManager.TimingSystems)
+            foreach (ITimingSystem timingSystem in timingSystemManager.AllSystems)
             {
                 TimingSystemStatusNode tsn = new TimingSystemStatusNode(timingSystemManager, timingSystem);
                 AddChild(tsn);
@@ -227,7 +227,11 @@ namespace UI.Nodes
 
             if (TimingSystem != null)
             {
-                if (TimingSystemManager.TimingSystemCount > 1)
+                if (TimingSystem is IRaceControlTimingSystem)
+                {
+                    Name = TimingSystem.Name;
+                }
+                else if (TimingSystemManager.TimingSystemCount > 1)
                 {
                     string[] nameOptions = new string[] { TimingSystem.Name, TimingSystem.Settings.Role.ToString().Substring(0, 3).ToUpper() };
                     Name = nameOptions.GetFromCurrentTime(updateEverySeconds);

--- a/UI/Nodes/TimingSystemEditor.cs
+++ b/UI/Nodes/TimingSystemEditor.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Timing;
+using Timing.ELRS;
 using Timing.ImmersionRC;
 using Timing.RotorHazard;
 using Timing.Velocidrone;
@@ -53,7 +54,7 @@ namespace UI.Nodes
         {
             Text = "Timing Settings";
 
-            ScanButton = new TextButtonNode("Scan Network", ButtonBackground, ButtonHover, TextColor);
+            ScanButton = new TextButtonNode("Scan Systems", ButtonBackground, ButtonHover, TextColor);
             buttonContainer.AddChild(ScanButton);
 
             Node[] buttons = new Node[] { ScanButton, addButton, removeButton, cancelButton, okButton };
@@ -69,7 +70,7 @@ namespace UI.Nodes
             LoadingLayer ll = GetLayer<LoadingLayer>();
             if (ll != null)
             {
-                ll.WorkQueue.Enqueue("Scanning Network", () =>
+                ll.WorkQueue.Enqueue("Scanning Systems", () =>
                 {
                     SubnetScanner ss = new SubnetScanner();
                     ss.Exceptions = Hostnames.ToArray();
@@ -77,7 +78,6 @@ namespace UI.Nodes
                     int lapRFPort = (new LapRFSettingsEthernet()).Port;
                     int rhPort = (new RotorHazardSettings()).Port;
                     int vdPort = (new VelocidroneSettings()).Port;
-
 
                     MouseMenu mouseMenu = new MouseMenu(ScanButton);
                     foreach(SubnetScanner.OpenPortsStruct openPort in ss.AliveWithOpenPorts(lapRFPort, rhPort, vdPort))
@@ -118,6 +118,17 @@ namespace UI.Nodes
                         }
                     }
 
+                    string elrsPort = VRXCProtocol.DetectPort();
+                    if (!string.IsNullOrEmpty(elrsPort))
+                    {
+                        mouseMenu.AddItem("Add ELRS Backpack - " + elrsPort, () =>
+                        {
+                            var elrs = new ELRSSettings();
+                            elrs.ComPort = elrsPort;
+                            AddNew(elrs);
+                        });
+                    }
+
                     mouseMenu.TopToBottom = false;
                     mouseMenu.Show(ScanButton);
 
@@ -135,6 +146,7 @@ namespace UI.Nodes
             mouseMenu.AddItem("RotorHazard 4.0+", () => { AddNew(new Timing.RotorHazard.RotorHazardSettings()); });
             mouseMenu.AddItem("Velocidrone", () => { AddNew(new VelocidroneSettings()); });
             mouseMenu.AddItem("Chorus32", () => { AddNew(new Timing.Chorus.ChorusSettings()); });
+            mouseMenu.AddItem("ELRS Backpack (Race Control)", () => { AddNew(new ELRSSettings()); });
             
             if (Timing.Aruco.ArucoTimingSystem.IsNativeAvailable())
                 mouseMenu.AddItem("ArUco (Video Marker)", () => { AddNew(new Timing.Aruco.ArucoTimingSettings()); });
@@ -169,6 +181,9 @@ namespace UI.Nodes
 
             foreach (var pi in base.GetPropertyInfos(obj))
             {
+                if (obj is ELRSSettings && pi.Name == "Role")
+                    continue;
+
                 if (lockRoleForArucoSplit && pi.Name == "Role")
                     continue;
 
@@ -198,12 +213,13 @@ namespace UI.Nodes
         protected override string ItemToString(TimingSystemSettings item)
         {
             string extraInfo = "";
-            
-            if (Objects.Count > 1)
+
+            int lapTimingSystemCount = Objects.Count(obj => !(obj is ELRSSettings));
+            if (!(item is ELRSSettings) && lapTimingSystemCount > 1)
             {
                 if (item.Role == TimingSystemRole.Split)
                 {
-                    extraInfo = " (Split " + (Objects.Where(r => r.Role == TimingSystemRole.Split).ToList().IndexOf(item) + 1) + ")";
+                    extraInfo = " (Split " + (Objects.Where(r => !(r is ELRSSettings) && r.Role == TimingSystemRole.Split).ToList().IndexOf(item) + 1) + ")";
                 }
                 else
                 {
@@ -232,9 +248,17 @@ namespace UI.Nodes
         
         protected override void AddNew(TimingSystemSettings t)
         {
-            if (Objects.Any())
+            if (t is ELRSSettings)
             {
                 t.Role = TimingSystemRole.Split;
+            }
+            else if (Objects.Any(obj => !(obj is ELRSSettings)))
+            {
+                t.Role = TimingSystemRole.Split;
+            }
+            else
+            {
+                t.Role = TimingSystemRole.Primary;
             }
             base.AddNew(t);
         }
@@ -247,7 +271,7 @@ namespace UI.Nodes
 
         private void CheckVisible()
         {
-            bool multipleCategoryVisible = Objects.Count > 1;
+            bool multipleCategoryVisible = Objects.Count(obj => !(obj is ELRSSettings)) > 1;
 
             foreach (var propertyNode in PropertyNodes)
             {

--- a/UI/Nodes/TimingSystemEditor.cs
+++ b/UI/Nodes/TimingSystemEditor.cs
@@ -54,7 +54,7 @@ namespace UI.Nodes
         {
             Text = "Timing Settings";
 
-            ScanButton = new TextButtonNode("Scan Systems", ButtonBackground, ButtonHover, TextColor);
+            ScanButton = new TextButtonNode("Scan", ButtonBackground, ButtonHover, TextColor);
             buttonContainer.AddChild(ScanButton);
 
             Node[] buttons = new Node[] { ScanButton, addButton, removeButton, cancelButton, okButton };
@@ -67,10 +67,19 @@ namespace UI.Nodes
 
         private void ScanButton_OnClick(MouseInputEvent mie)
         {
+            MouseMenu mouseMenu = new MouseMenu(ScanButton);
+            mouseMenu.AddItem("Scan Network", ScanNetwork);
+            mouseMenu.AddItem("Scan Serial", ScanSerial);
+            mouseMenu.TopToBottom = false;
+            mouseMenu.Show(ScanButton);
+        }
+
+        private void ScanNetwork()
+        {
             LoadingLayer ll = GetLayer<LoadingLayer>();
             if (ll != null)
             {
-                ll.WorkQueue.Enqueue("Scanning Systems", () =>
+                ll.WorkQueue.Enqueue("Scanning Network", () =>
                 {
                     SubnetScanner ss = new SubnetScanner();
                     ss.Exceptions = Hostnames.ToArray();
@@ -88,7 +97,7 @@ namespace UI.Nodes
 
                             if (port == lapRFPort)
                             {
-                                mouseMenu.AddItem("Add LapRF 8way - " + copy, () => 
+                                mouseMenu.AddItem("Add LapRF 8way - " + copy, () =>
                                 {
                                     var laprf = new LapRFSettingsEthernet();
                                     laprf.HostName = copy.ToString();
@@ -98,7 +107,7 @@ namespace UI.Nodes
 
                             if (port == rhPort)
                             {
-                                mouseMenu.AddItem("Add RotorHazard - " + copy, () => 
+                                mouseMenu.AddItem("Add RotorHazard - " + copy, () =>
                                 {
                                     var rotorhazard = new RotorHazardSettings();
                                     rotorhazard.HostName = copy.ToString();
@@ -108,7 +117,7 @@ namespace UI.Nodes
 
                             if (port == vdPort)
                             {
-                                mouseMenu.AddItem("Add Velocidrone - " + copy, () => 
+                                mouseMenu.AddItem("Add Velocidrone - " + copy, () =>
                                 {
                                     var velocidrone = new VelocidroneSettings();
                                     velocidrone.HostName = copy.ToString();
@@ -118,9 +127,26 @@ namespace UI.Nodes
                         }
                     }
 
+                    mouseMenu.TopToBottom = false;
+                    mouseMenu.Show(ScanButton);
+                });
+            }
+        }
+
+        private void ScanSerial()
+        {
+            LoadingLayer ll = GetLayer<LoadingLayer>();
+            if (ll != null)
+            {
+                ll.WorkQueue.Enqueue("Scanning Serial", () =>
+                {
+                    MouseMenu mouseMenu = new MouseMenu(ScanButton);
+                    bool foundAny = false;
+
                     string elrsPort = VRXCProtocol.DetectPort();
                     if (!string.IsNullOrEmpty(elrsPort))
                     {
+                        foundAny = true;
                         mouseMenu.AddItem("Add ELRS Backpack - " + elrsPort, () =>
                         {
                             var elrs = new ELRSSettings();
@@ -129,9 +155,25 @@ namespace UI.Nodes
                         });
                     }
 
+                    string lapRFPort = LapRFTimingUSB.DetectPort();
+                    if (!string.IsNullOrEmpty(lapRFPort))
+                    {
+                        foundAny = true;
+                        mouseMenu.AddItem("Add LapRF Puck - " + lapRFPort, () =>
+                        {
+                            var laprf = new LapRFSettingsUSB();
+                            laprf.ComPort = lapRFPort;
+                            AddNew(laprf);
+                        });
+                    }
+
+                    if (!foundAny)
+                    {
+                        mouseMenu.AddItem("No serial timing systems found", () => { });
+                    }
+
                     mouseMenu.TopToBottom = false;
                     mouseMenu.Show(ScanButton);
-
                 });
             }
         }


### PR DESCRIPTION
## Summary

- add serial MSP v2 support for ExpressLRS timer backpacks
- allow the transmitter `DVR Rec` switch to start and stop Trackside races
- treat the backpack as a race-control accessory instead of a lap timing system
- add validated device scanning, connection status, configuration, and setup documentation

## Why

The community VRxC ELRS integration already supports race control through the
ExpressLRS backpack protocol, but Trackside did not have an equivalent
integration. An earlier implementation was based on an old Trackside revision
and added race-control events to every timing system. This port targets the
current .NET 9 codebase and isolates race-control behavior behind an optional
interface, keeping it out of the primary/split lap-detection pipeline.

Commands are marshalled onto Trackside's UI thread and use the same start/stop
paths as the normal controls, preserving video checks, configured start delays,
staging cancellation, recording, and UI updates.

## Protocol

- serial: 460800 baud, 8-N-1
- MSP v2 version handshake: `0x0010`
- recording/race state command: `0x0305`
- CRC-8/DVB-S2 validation

The protocol and baud rate were checked against the current
`i-am-grub/vrxc_elrs` implementation.

## Validation

- `dotnet build Timing/Timing.csproj --configuration Release`
- `dotnet build UI/UI.csproj --configuration Release`
- synthetic protocol check covering fragmented start/stop packets and CRC rejection
- XML round-trip check for `ELRSSettings`

## Hardware follow-up

Hardware verification is still required with an ELRS timer backpack and bound
transmitter. The included README lists the start, staging-cancel, and stop
checks to perform.
