### PR TITLE
Fix clipped text on macOS by measuring to the glyph right edge

### DIFF
--- a/FPVMacSideCore/TextRenderSkia.cs
+++ b/FPVMacSideCore/TextRenderSkia.cs
@@ -119,7 +119,7 @@ namespace FPVMacsideCore
                     {
                         SKRect lineBounds = new SKRect();
                         paint.MeasureText(line, ref lineBounds);
-                        maxWidth = Math.Max(maxWidth, lineBounds.Width);
+                        maxWidth = Math.Max(maxWidth, lineBounds.Right);
                     }
 
                     // Check if we need to scale down to fit width
@@ -140,7 +140,7 @@ namespace FPVMacsideCore
                         {
                             SKRect lineBounds = new SKRect();
                             adjustedPaint.MeasureText(line, ref lineBounds);
-                            maxWidth = Math.Max(maxWidth, lineBounds.Width);
+                            maxWidth = Math.Max(maxWidth, lineBounds.Right);
 
                             // Calculate character bounds for hit testing
                             float x = 0;


### PR DESCRIPTION
## Problem

On macOS the last glyph of a rendered string is clipped on its right edge. It is most obvious on the position overlay in the pilot video panels, where `10th` renders as `10tr`, but it affects every string the app draws on macOS.

## Cause

`FPVMacSideCore/TextRenderSkia.cs` sizes its `SKSurface` from `SKRect.Width` — the width of the tight ink bounding box:

```csharp
paint.MeasureText(line, ref lineBounds);
maxWidth = Math.Max(maxWidth, lineBounds.Width);
```

but draws the text at `x = 0`, the pen origin:

```csharp
canvas.DrawText(line, 0, yPos, paint);
```

`SKRect.Width` is `Right - Left`, so it discards the left side bearing. Relative to the origin the ink actually occupies `[Left, Right]`, so the surface needs to be `Right` wide. It ends up too narrow by exactly `Left`, and the surface edge clips the result.

The shortfall is a per-string constant rather than proportional to length, which is why short strings such as `1st` clip as much as `11th`. The 3px border stroke drawn when `Style.Border` is set makes it more visible.

## Fix

Measure with `SKRect.Right`, which is the ink extent relative to the origin and therefore matches where the text is drawn.

`FPVTuxSideCore/TextRenderSkia.cs` — the same renderer, for Linux — already measures this way (lines 126 and 147). This change only brings the macOS copy in line with it.

Windows is unaffected: `TextRenderWPF` measures with `FormattedText.Width`, which already accounts for bearings.

## Testing

Built and ran on macOS 26.5.2, Apple Silicon, .NET 9. Verified against the position overlay and checked general UI text for regressions.

Not tested on Windows or Linux. This file is macOS-only and is not compiled by either platform, so neither is affected by the change.

### Before
<img width="1364" height="917" alt="PositionOverlay_Clipped" src="https://github.com/user-attachments/assets/02e1ccae-9d94-40c0-b9c5-e132cfeb88b6" />

### After
<img width="1134" height="954" alt="PositionOverlay_Fixed" src="https://github.com/user-attachments/assets/f3f8dad2-2ad0-4f50-bb54-13ff9ede230f" />