### PR TITLE
Fix ArUco on macOS: bundle the OpenCV dylibs without needing a publish flag

### DIFF
--- a/FPVMacSideCore/FPVMacsideCore.csproj
+++ b/FPVMacSideCore/FPVMacsideCore.csproj
@@ -19,6 +19,24 @@
       <Link>Translations.xlsx</Link>
     </Content>
   </ItemGroup>
+
+  <!-- macOS arm64: locally-built libOpenCvSharpExtern.dylib (linked against OpenCV 4.11 + opencv_contrib,
+       includes ArUco) together with all OpenCV / dependency dylibs it loads at runtime. They go under
+       runtimes/osx-arm64/native/ because that's where Timing/Aruco/OpenCvNativeResolver.cs probes.
+       Bundled here rather than in Timing.csproj because $(RuntimeIdentifier) is only reliably set on the
+       app being published — as a RID-agnostic project reference Timing sees it empty, so it could not
+       tell an osx-arm64 publish from any other and needed an explicit -p:BundleMacDylibs=true that a
+       release build could forget. The RID condition keeps the ~280MB out of osx-x64 and RID-less builds;
+       Windows and Linux never build this project at all. BundleMacDylibs is still honoured so the
+       previously documented publish command keeps working. TargetPath is used instead of Link so the
+       output path is explicit and SDK-version-independent. -->
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64' Or '$(BundleMacDylibs)' == 'true'">
+    <Content Include="..\Timing\native\osx-arm64\*.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>runtimes/osx-arm64/native/%(Filename)%(Extension)</TargetPath>
+      <Visible>false</Visible>
+    </Content>
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.8" />

--- a/Timing/Timing.csproj
+++ b/Timing/Timing.csproj
@@ -35,25 +35,11 @@
     </None>
   </ItemGroup>
 
-  <!-- macOS arm64: locally-built libOpenCvSharpExtern.dylib (linked against OpenCV 4.11 + opencv_contrib,
-       includes ArUco) together with all OpenCV / dependency dylibs it loads at runtime. They are placed
-       under runtimes/osx-arm64/native/ because that's where OpenCvSharp4's native loader searches.
-       Included only when the build actually targets osx-arm64 so Windows and other-RID builds are not
-       bloated by the ~280MB of Mac dylibs. Two triggers, because $(RuntimeIdentifier) is NOT set when
-       Timing is built as a RID-agnostic project reference of an app being published for osx-arm64:
-         - '$(RuntimeIdentifier)' == 'osx-arm64'  -> direct `dotnet publish Timing -r osx-arm64`
-         - '$(BundleMacDylibs)' == 'true'         -> set via `-p:BundleMacDylibs=true` on the app publish;
-                                                     global -p: properties propagate to all references.
-       So publish the Mac app with: dotnet publish FPVMacSideCore -r osx-arm64 -p:BundleMacDylibs=true
-       Unlike the previous build-host check, neither trigger depends on the build host OS, so cross-
-       publishing from Windows works. TargetPath is used instead of Link so the output path is explicit
-       and SDK-version-independent. -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64' Or '$(BundleMacDylibs)' == 'true'">
-    <Content Include="native/osx-arm64/*.dylib">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>runtimes/osx-arm64/native/%(Filename)%(Extension)</TargetPath>
-      <Visible>false</Visible>
-    </Content>
-  </ItemGroup>
+  <!-- The macOS arm64 OpenCV / ArUco dylibs that live in native/osx-arm64/ are bundled by the Mac app
+       project (FPVMacSideCore/FPVMacsideCore.csproj), not here. $(RuntimeIdentifier) is empty when
+       Timing is built as a RID-agnostic project reference of an app being published for osx-arm64, so
+       a condition in this file could only be driven by an opt-in flag — and a release publish that
+       forgot the flag silently shipped with no dylibs at all. The app project always has the RID set,
+       so bundling there needs no flag and cannot be forgotten. -->
 
 </Project>

--- a/documentation/DeveloperGuide.md
+++ b/documentation/DeveloperGuide.md
@@ -606,13 +606,23 @@ public void TestEventCreation()
 dotnet publish FPVTracksideCore/FPVTracksideCore.csproj -c Release -r win-x64 --self-contained
 
 # macOS Release Build (Apple Silicon / arm64)
-# -p:BundleMacDylibs=true is REQUIRED to bundle the OpenCV/ArUco native dylibs
-# (Timing/native/osx-arm64/*.dylib) into runtimes/osx-arm64/native/. It is a global
-# property so it propagates to the referenced Timing project; without it the ArUco
-# dylibs are NOT copied. Windows builds omit the flag so they are not bloated by the
-# ~280MB of Mac dylibs.
-dotnet publish FPVMacSideCore/FPVMacsideCore.csproj -c Release -r osx-arm64 --self-contained -p:BundleMacDylibs=true
+# The -r osx-arm64 RID alone bundles the OpenCV/ArUco native dylibs
+# (Timing/native/osx-arm64/*.dylib) into runtimes/osx-arm64/native/ — no extra flag needed.
+# Other RIDs and RID-less builds skip them, so nothing else is bloated by the ~280MB.
+dotnet publish FPVMacSideCore/FPVMacsideCore.csproj -c Release -r osx-arm64 --self-contained
 ```
+
+After publishing, confirm the natives actually made it into the output — if this folder is
+missing or empty, ArUco will fail at runtime with `DllNotFoundException` and everything else
+in the app will still look fine:
+
+```bash
+ls bin/Release-publish/osx-arm64/runtimes/osx-arm64/native/libOpenCvSharpExtern.dylib
+```
+
+The same check applies to a packaged `.dmg`: mount it and verify
+`FPVTrackside.app/Contents/.../runtimes/osx-arm64/native/` contains
+`libOpenCvSharpExtern.dylib` plus the `libopencv_*.dylib` set.
 
 > **ArUco detection is only supported on `osx-arm64` (Apple Silicon).**
 > Only arm64 OpenCV dylibs are bundled, so an Intel **`osx-x64` build CANNOT perform

--- a/documentation/QuickReference.md
+++ b/documentation/QuickReference.md
@@ -238,8 +238,9 @@ dotnet run --configuration Release
 # Windows Release
 dotnet publish FPVTracksideCore/FPVTracksideCore.csproj -c Release -r win-x64 --self-contained
 
-# macOS Release
-dotnet publish FPVMacSideCore/FPVMacsideCore.csproj -c Release -r osx-x64 --self-contained
+# macOS Release (Apple Silicon — osx-arm64 also bundles the OpenCV/ArUco dylibs;
+# an osx-x64 build cannot do ArUco detection)
+dotnet publish FPVMacSideCore/FPVMacsideCore.csproj -c Release -r osx-arm64 --self-contained
 ```
 
 ### Package Creation


### PR DESCRIPTION
Follow-up to #58. @zubon2003 reported that ArUco still does not work in the `FPVTrackside 2.77.0.874.dmg` build, and that the `runtimes` folder with `libOpenCvSharpExtern.dylib` and its dependency dylibs is missing from the dmg entirely. That report is correct, and this is a packaging problem rather than anything wrong with #58 — the dylibs are committed and the resolver works.

## Root cause

`Timing/Timing.csproj` gated the dylib bundling on:

```xml
<ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64' Or '$(BundleMacDylibs)' == 'true'">
```

`$(RuntimeIdentifier)` is empty when `Timing` is built as a RID-agnostic project reference of the Mac app being published, so the RID trigger never fires in a real app publish. That left `-p:BundleMacDylibs=true` as the only working trigger, and a publish that omitted the flag produced **no `runtimes/` folder at all** — silently. The app still builds, launches and behaves normally; the only symptom is `DllNotFoundException` the moment ArUco is used.

Reproduced on Apple Silicon against current `master`:

| publish command | `runtimes/osx-arm64/native/` |
| --- | --- |
| `-r osx-arm64` | **absent, 0 dylibs** — matches the shipped dmg |
| `-r osx-arm64 -p:BundleMacDylibs=true` | 179 dylibs incl. `libOpenCvSharpExtern.dylib` |

## Fix

Move the bundling out of `Timing.csproj` and into `FPVMacSideCore/FPVMacsideCore.csproj`, where the RID is always set. A plain `-r osx-arm64` publish is now self-sufficient and the flag cannot be forgotten. `BundleMacDylibs=true` is still honoured, so the previously documented publish command keeps working unchanged.

## Verification

On a clean checkout of `master` with this change, publishing with `-r osx-arm64` and **no** flag:

- 179 dylibs land in `runtimes/osx-arm64/native/`, including `libOpenCvSharpExtern.dylib` and `libopencv_aruco.411.dylib`
- `libOpenCvSharpExtern.dylib` dlopens standalone from the publish output, with no `/opt/homebrew` or `/usr/local` references remaining
- RID-less and non-`osx-arm64` builds bundle 0 dylibs, so the ~280MB stays out of them
- `Timing.csproj` now carries no dylib content at all, and the Windows app never referenced the Mac project, so Windows builds are unaffected

## Note for the next release build

This only fixes builds made from here on — **2.77.0.874 needs to be rebuilt regardless**. If a working dmg is wanted before this merges, publishing current `master` with `-p:BundleMacDylibs=true` produces one today.

## Docs

`DeveloperGuide.md` and `QuickReference.md` updated to drop the "the flag is REQUIRED" wording, and to add a post-publish check of `runtimes/osx-arm64/native/libOpenCvSharpExtern.dylib`. Because this failure is invisible in the app itself, it is worth checking the packaged dmg too. `QuickReference.md` also listed the macOS release build as `-r osx-x64`, which can never do ArUco detection — corrected to `osx-arm64`.