### PR TITLE
Fix macOS data paths so the Open Directory menus point at the real data (#25)

### DIFF
--- a/DB/JSON/ChannelCollection.cs
+++ b/DB/JSON/ChannelCollection.cs
@@ -17,7 +17,7 @@ namespace DB.JSON
             if (firstRun)
             {
                 JsonIO<Channel> io = new JsonIO<Channel>();
-                io.Write(IOTools.Resolve(Path.Combine("httpfiles", "Channels.json")), All());
+                io.Write(IOTools.ResolveFromWorkingDirectory("httpfiles", "Channels.json"), All());
                 firstRun = false;
             }
         }

--- a/DB/JSON/ChannelCollection.cs
+++ b/DB/JSON/ChannelCollection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Tools;
 
 namespace DB.JSON
 {
@@ -16,7 +17,7 @@ namespace DB.JSON
             if (firstRun)
             {
                 JsonIO<Channel> io = new JsonIO<Channel>();
-                io.Write(Path.Combine("httpfiles", "Channels.json"), All());
+                io.Write(IOTools.Resolve(Path.Combine("httpfiles", "Channels.json")), All());
                 firstRun = false;
             }
         }

--- a/DB/JSON/JsonDatabase.cs
+++ b/DB/JSON/JsonDatabase.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Tools;
 
 namespace DB.JSON
 {
@@ -46,7 +47,7 @@ namespace DB.JSON
             Clubs = new JsonCollection<Club>(DataDirectory);
             Channels = new ChannelCollection();
 
-            DirectoryInfo trackDir = new DirectoryInfo("Tracks");
+            DirectoryInfo trackDir = new DirectoryInfo(IOTools.Resolve("Tracks"));
             if (!trackDir.Exists)
             {
                 trackDir.Create();

--- a/DB/JSON/JsonDatabase.cs
+++ b/DB/JSON/JsonDatabase.cs
@@ -47,7 +47,7 @@ namespace DB.JSON
             Clubs = new JsonCollection<Club>(DataDirectory);
             Channels = new ChannelCollection();
 
-            DirectoryInfo trackDir = new DirectoryInfo(IOTools.Resolve("Tracks"));
+            DirectoryInfo trackDir = new DirectoryInfo(IOTools.ResolveFromWorkingDirectory("Tracks"));
             if (!trackDir.Exists)
             {
                 trackDir.Create();

--- a/ExternalData/ExtensionNotifier.cs
+++ b/ExternalData/ExtensionNotifier.cs
@@ -288,7 +288,10 @@ namespace ExternalData
 
         private HelloMessage BuildHello()
         {
-            string workingDir = NormalizeDir(Directory.GetCurrentDirectory());
+            // The data root, not the process's current directory. On macOS the two are
+            // deliberately different - the cwd is the app bundle, the data lives under the
+            // user's home - and every path below this describes where the data is.
+            string workingDir = NormalizeDir(IOTools.WorkingDirectory?.FullName ?? Directory.GetCurrentDirectory());
             string baseDir = NormalizeDir(AppDomain.CurrentDomain.BaseDirectory ?? workingDir);
             string eventsDirRaw = string.IsNullOrEmpty(eventStorageLocation) ? "events" : eventStorageLocation;
             string eventsDir = NormalizeDir(Path.IsPathRooted(eventsDirRaw)

--- a/FPVMacSideCore/FPVMacsideCoreGame.cs
+++ b/FPVMacSideCore/FPVMacsideCoreGame.cs
@@ -37,7 +37,7 @@ namespace FPVMacsideCore
             FfmpegMediaPlatform.FfmpegGlobalInitializer.Initialize();
 
             Theme.Initialise(GraphicsDevice, PlatformTools.WorkingDirectory, "Dark");
-            DirectoryInfo eventDir = new DirectoryInfo(ApplicationProfileSettings.Instance.EventStorageLocation);
+            DirectoryInfo eventDir = new DirectoryInfo(ApplicationProfileSettings.Instance.EventStoragePath);
             DatabaseFactory.Init(new DB.DatabaseFactory(Data, eventDir));
 
 

--- a/FPVTracksideCore/FPVTracksideCoreGame.cs
+++ b/FPVTracksideCore/FPVTracksideCoreGame.cs
@@ -53,7 +53,7 @@ namespace FPVTracksideCore
 
         protected override void LoadContent()
         {
-            DirectoryInfo eventDir = new DirectoryInfo(ApplicationProfileSettings.Instance.EventStorageLocation);
+            DirectoryInfo eventDir = new DirectoryInfo(ApplicationProfileSettings.Instance.EventStoragePath);
             DatabaseFactory.Init(new DB.DatabaseFactory(Data, eventDir));
 
             Theme.Initialise(GraphicsDevice, PlatformTools.WorkingDirectory, "FPVTrackside");

--- a/FPVTuxSideCore/FPVTuxsideCoreGame.cs
+++ b/FPVTuxSideCore/FPVTuxsideCoreGame.cs
@@ -80,7 +80,7 @@ namespace FPVTuxsideCore
             FfmpegMediaPlatform.FfmpegGlobalInitializer.Initialize();
 
             Theme.Initialise(GraphicsDevice, PlatformTools.WorkingDirectory, "Dark");
-            DirectoryInfo eventDir = new DirectoryInfo(ApplicationProfileSettings.Instance.EventStorageLocation);
+            DirectoryInfo eventDir = new DirectoryInfo(ApplicationProfileSettings.Instance.EventStoragePath);
             DatabaseFactory.Init(new DB.DatabaseFactory(Data, eventDir));
 
             base.LoadContent();

--- a/RaceLib/Format/SheetFormatManager.cs
+++ b/RaceLib/Format/SheetFormatManager.cs
@@ -40,7 +40,7 @@ namespace RaceLib.Format
         }
 
         public SheetFormatManager(RoundManager roundManager)
-            :this(roundManager, new DirectoryInfo("formats"))
+            :this(roundManager, new DirectoryInfo(IOTools.Resolve("formats")))
         {
         }
 

--- a/RaceLib/Format/SheetFormatManager.cs
+++ b/RaceLib/Format/SheetFormatManager.cs
@@ -40,7 +40,7 @@ namespace RaceLib.Format
         }
 
         public SheetFormatManager(RoundManager roundManager)
-            :this(roundManager, new DirectoryInfo(IOTools.Resolve("formats")))
+            :this(roundManager, new DirectoryInfo(IOTools.ResolveFromWorkingDirectory("formats")))
         {
         }
 

--- a/RaceLib/ProfilePictures.cs
+++ b/RaceLib/ProfilePictures.cs
@@ -22,7 +22,7 @@ namespace RaceLib
 
         public IEnumerable<FileInfo> GetPilotProfileMedia()
         {
-            DirectoryInfo pilotProfileDirectory = new DirectoryInfo(IOTools.Resolve("pilots"));
+            DirectoryInfo pilotProfileDirectory = new DirectoryInfo(IOTools.ResolveFromWorkingDirectory("pilots"));
 
             if (pilotProfileDirectory.Exists)
             {
@@ -71,7 +71,7 @@ namespace RaceLib
                         }
                         if (!string.IsNullOrEmpty(p.PhotoPath))
                         {
-                            p.PhotoPath = Path.GetRelativePath(workingDirectory, IOTools.Resolve(p.PhotoPath));
+                            p.PhotoPath = Path.GetRelativePath(workingDirectory, IOTools.ResolveFromWorkingDirectory(p.PhotoPath));
                         }
                     }
                     catch (Exception ex)

--- a/RaceLib/ProfilePictures.cs
+++ b/RaceLib/ProfilePictures.cs
@@ -43,7 +43,7 @@ namespace RaceLib
 
         public void FindProfilePictures(Pilot[] pilots)
         {
-            string currentDirectory = Directory.GetCurrentDirectory();
+            string workingDirectory = IOTools.WorkingDirectory.FullName;
 
             List<string> listOfExt = extensions.ToList();
 
@@ -71,7 +71,7 @@ namespace RaceLib
                         }
                         if (!string.IsNullOrEmpty(p.PhotoPath))
                         {
-                            p.PhotoPath = Path.GetRelativePath(currentDirectory, p.PhotoPath);
+                            p.PhotoPath = Path.GetRelativePath(workingDirectory, IOTools.Resolve(p.PhotoPath));
                         }
                     }
                     catch (Exception ex)

--- a/RaceLib/ProfilePictures.cs
+++ b/RaceLib/ProfilePictures.cs
@@ -22,7 +22,7 @@ namespace RaceLib
 
         public IEnumerable<FileInfo> GetPilotProfileMedia()
         {
-            DirectoryInfo pilotProfileDirectory = new DirectoryInfo("pilots");
+            DirectoryInfo pilotProfileDirectory = new DirectoryInfo(IOTools.Resolve("pilots"));
 
             if (pilotProfileDirectory.Exists)
             {

--- a/Sound/SoundEffectManager.cs
+++ b/Sound/SoundEffectManager.cs
@@ -146,7 +146,7 @@ namespace Sound
         {
             if (!File.Exists(filename))
             {
-                filename = Directory.GetCurrentDirectory() + "\\" + filename;
+                filename = IOTools.Resolve(filename);
             }
 
             if (File.Exists(filename) && !effects.ContainsKey(filename))

--- a/Sound/SoundEffectManager.cs
+++ b/Sound/SoundEffectManager.cs
@@ -146,7 +146,7 @@ namespace Sound
         {
             if (!File.Exists(filename))
             {
-                filename = IOTools.Resolve(filename);
+                filename = IOTools.ResolveFromWorkingDirectory(filename);
             }
 
             if (File.Exists(filename) && !effects.ContainsKey(filename))

--- a/Tools/IOTools.cs
+++ b/Tools/IOTools.cs
@@ -29,7 +29,16 @@ namespace Tools
             if (Path.IsPathRooted(path))
                 return path;
 
-            return Path.GetFullPath(Path.Combine(root, path));
+            try
+            {
+                return Path.GetFullPath(Path.Combine(root, path));
+            }
+            catch (Exception)
+            {
+                // Not a usable path - a URL, or characters the platform rejects. Hand it back
+                // untouched so callers fail exactly the way they did before.
+                return path;
+            }
         }
 
         /// <summary>

--- a/Tools/IOTools.cs
+++ b/Tools/IOTools.cs
@@ -14,6 +14,33 @@ namespace Tools
     {
         public static DirectoryInfo WorkingDirectory { get; set; }
 
+        /// <summary>
+        /// Resolves a relative path to an absolute path based on WorkingDirectory.
+        /// Absolute paths are returned as-is. Falls back to the current directory, as before,
+        /// when WorkingDirectory is not yet set.
+        /// </summary>
+        public static string Resolve(string path)
+        {
+            string root = WorkingDirectory?.FullName ?? Directory.GetCurrentDirectory();
+
+            if (string.IsNullOrEmpty(path))
+                return root;
+
+            if (Path.IsPathRooted(path))
+                return path;
+
+            return Path.GetFullPath(Path.Combine(root, path));
+        }
+
+        /// <summary>
+        /// Converts an absolute path to a path relative to WorkingDirectory, for storage.
+        /// </summary>
+        public static string Relativize(string fullPath)
+        {
+            string root = WorkingDirectory?.FullName ?? Directory.GetCurrentDirectory();
+            return Path.GetRelativePath(root, fullPath);
+        }
+
         public static T[] Read<T>(Profile profile, string filename) where T : new()
         {
             return Read<T>(profile.GetPath(), filename, null);

--- a/Tools/IOTools.cs
+++ b/Tools/IOTools.cs
@@ -19,12 +19,14 @@ namespace Tools
         /// Absolute paths are returned as-is. Falls back to the current directory, as before,
         /// when WorkingDirectory is not yet set.
         /// </summary>
-        public static string Resolve(string path)
+        public static string ResolveFromWorkingDirectory(params string[] pathsToCombine)
         {
             string root = WorkingDirectory?.FullName ?? Directory.GetCurrentDirectory();
 
-            if (string.IsNullOrEmpty(path))
+            if (pathsToCombine == null || pathsToCombine.Length == 0 || pathsToCombine.Any(string.IsNullOrEmpty))
                 return root;
+
+            string path = Path.Combine(pathsToCombine);
 
             if (Path.IsPathRooted(path))
                 return path;
@@ -44,7 +46,7 @@ namespace Tools
         /// <summary>
         /// Converts an absolute path to a path relative to WorkingDirectory, for storage.
         /// </summary>
-        public static string Relativize(string fullPath)
+        public static string RelativiseToWorkingDirectory(string fullPath)
         {
             string root = WorkingDirectory?.FullName ?? Directory.GetCurrentDirectory();
             return Path.GetRelativePath(root, fullPath);

--- a/Tools/TextureCache.cs
+++ b/Tools/TextureCache.cs
@@ -73,6 +73,11 @@ namespace Tools
             // mac compatibility.
             filename = filename.Replace("\\", "/");
 
+            // Relative paths (img/..., themes/... etc) are relative to the working
+            // directory, not to the current directory, which on macOS points inside
+            // the app bundle.
+            filename = IOTools.Resolve(filename);
+
             Texture2D texture;
             lock (stringToTexture)
             {

--- a/Tools/TextureCache.cs
+++ b/Tools/TextureCache.cs
@@ -76,7 +76,7 @@ namespace Tools
             // Relative paths (img/..., themes/... etc) are relative to the working
             // directory, not to the current directory, which on macOS points inside
             // the app bundle.
-            filename = IOTools.Resolve(filename);
+            filename = IOTools.ResolveFromWorkingDirectory(filename);
 
             Texture2D texture;
             lock (stringToTexture)

--- a/UI/ApplicationProfileSettings.cs
+++ b/UI/ApplicationProfileSettings.cs
@@ -91,6 +91,34 @@ namespace UI
         [NeedsRestart]
         public string EventStorageLocation { get; set; }
 
+        /// <summary>
+        /// EventStorageLocation resolved against IOTools.WorkingDirectory.
+        /// Use this everywhere the location is actually opened; the setting itself
+        /// stays relative so it remains portable between machines.
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnore]
+        [Browsable(false)]
+        public string EventStoragePath
+        {
+            get
+            {
+                string location = EventStorageLocation;
+
+                // Trim off some legacy slashes.
+                if (!string.IsNullOrEmpty(location) && (location.EndsWith("/") || location.EndsWith("\\")))
+                {
+                    location = location.Substring(0, location.Length - 1);
+                }
+
+                if (string.IsNullOrEmpty(location))
+                {
+                    location = "events";
+                }
+
+                return IOTools.Resolve(location);
+            }
+        }
+
         [Category("Static Detector")]
         [NeedsRestart]
         public bool VideoStaticDetector { get; set; }

--- a/UI/ApplicationProfileSettings.cs
+++ b/UI/ApplicationProfileSettings.cs
@@ -115,7 +115,7 @@ namespace UI
                     location = "events";
                 }
 
-                return IOTools.Resolve(location);
+                return IOTools.ResolveFromWorkingDirectory(location);
             }
         }
 

--- a/UI/EventLayer.cs
+++ b/UI/EventLayer.cs
@@ -101,7 +101,7 @@ namespace UI
                 Logger.UI.LogException(this, ex);
             }
 
-            DirectoryInfo eventDirectory = new DirectoryInfo(Path.Combine(ApplicationProfileSettings.Instance.EventStorageLocation, eventManager.Event.ID.ToString()));
+            DirectoryInfo eventDirectory = new DirectoryInfo(Path.Combine(ApplicationProfileSettings.Instance.EventStoragePath, eventManager.Event.ID.ToString()));
 
             workQueueStartStopRace = new WorkQueue("Event Layer - Start Stop Race");
 
@@ -301,7 +301,7 @@ namespace UI
                 raceControl = this;
             }
 
-            eventWebServer = new EventWebServer(EventManager, SoundManager, raceControl, Theme.Current.ChannelColors, ApplicationProfileSettings.Instance.EventStorageLocation);
+            eventWebServer = new EventWebServer(EventManager, SoundManager, raceControl, Theme.Current.ChannelColors, ApplicationProfileSettings.Instance.EventStoragePath);
 
             if (ApplicationProfileSettings.Instance.HTTPServer)
             {
@@ -424,7 +424,7 @@ namespace UI
                     ApplicationProfileSettings.Instance.NotificationURL,
                     ApplicationProfileSettings.Instance.NotificationSerialPort,
                     Profile,
-                    ApplicationProfileSettings.Instance.EventStorageLocation,
+                    ApplicationProfileSettings.Instance.EventStoragePath,
                     ApplicationProfileSettings.Instance.ShownDecimalPlaces);
                     break;
             }

--- a/UI/EventLayer.cs
+++ b/UI/EventLayer.cs
@@ -1606,7 +1606,7 @@ namespace UI
         {
             long lowSpace = 1024 * 1024 * 1024; //1gb
 
-            DriveInfo drive = new DriveInfo(Directory.GetCurrentDirectory());
+            DriveInfo drive = new DriveInfo(IOTools.WorkingDirectory.FullName);
             try
             {
                 if (drive.AvailableFreeSpace < lowSpace)

--- a/UI/Nodes/MenuButton.cs
+++ b/UI/Nodes/MenuButton.cs
@@ -639,22 +639,7 @@ namespace UI.Nodes
             // Special handling for "events" paths - use the same logic as HTTP service
             if (paths.Any() && paths[0] == "events")
             {
-                string eventsPath = ApplicationProfileSettings.Instance.EventStorageLocation;
-
-                // Trim off some legacy slashes.
-                if (eventsPath.EndsWith("/") || eventsPath.EndsWith("\\"))
-                {
-                    eventsPath = eventsPath.Substring(0, eventsPath.Length - 1);
-                }
-
-                if (string.IsNullOrEmpty(eventsPath))
-                {
-                    eventsPath = Path.Combine(IOTools.WorkingDirectory?.FullName ?? "", "events");
-                }
-                else if (!Path.IsPathRooted(eventsPath))
-                {
-                    eventsPath = Path.Combine(IOTools.WorkingDirectory?.FullName ?? "", eventsPath);
-                }
+                string eventsPath = ApplicationProfileSettings.Instance.EventStoragePath;
 
                 // Append any additional path components after "events"
                 if (paths.Length > 1)

--- a/UI/Nodes/PilotChannelNode.cs
+++ b/UI/Nodes/PilotChannelNode.cs
@@ -98,7 +98,7 @@ namespace UI.Nodes
                 return;
             }
 
-            profileIcon.Visible = System.IO.File.Exists(Pilot.PhotoPath);
+            profileIcon.Visible = System.IO.File.Exists(IOTools.Resolve(Pilot.PhotoPath));
 
             if (profileIcon.Visible)
             {

--- a/UI/Nodes/PilotChannelNode.cs
+++ b/UI/Nodes/PilotChannelNode.cs
@@ -98,7 +98,7 @@ namespace UI.Nodes
                 return;
             }
 
-            profileIcon.Visible = System.IO.File.Exists(IOTools.Resolve(Pilot.PhotoPath));
+            profileIcon.Visible = System.IO.File.Exists(IOTools.ResolveFromWorkingDirectory(Pilot.PhotoPath));
 
             if (profileIcon.Visible)
             {

--- a/UI/Nodes/PilotProfileNode.cs
+++ b/UI/Nodes/PilotProfileNode.cs
@@ -166,6 +166,9 @@ namespace UI.Nodes
 
                 string repaired = System.Text.RegularExpressions.Regex.Replace(filename, @"[^\w\-. \/\\:]", "");
 
+                // Photo paths are stored relative to the working directory.
+                repaired = IOTools.Resolve(repaired);
+
                 FileInfo fileInfo = new FileInfo(repaired);
                 if (fileInfo.Exists)
                 {
@@ -186,11 +189,11 @@ namespace UI.Nodes
                         FileFrameNode videoPlayer;
                         if (ApplicationProfileSettings.Instance.PilotProfileChromaKey)
                         {
-                            source = new ChromaKeyCachedTextureFrameSource(CompositorLayer.GraphicsDevice, VideoFrameWorks.GetFramework(FrameWork.MediaFoundation), filename, ApplicationProfileSettings.Instance.PilotProfileChromaKeyColor, ApplicationProfileSettings.Instance.PilotProfileChromaKeyLimit);
+                            source = new ChromaKeyCachedTextureFrameSource(CompositorLayer.GraphicsDevice, VideoFrameWorks.GetFramework(FrameWork.MediaFoundation), repaired, ApplicationProfileSettings.Instance.PilotProfileChromaKeyColor, ApplicationProfileSettings.Instance.PilotProfileChromaKeyLimit);
                         }
                         else
                         {
-                            source = new CachedTextureFrameSource(CompositorLayer.GraphicsDevice, VideoFrameWorks.GetFramework(FrameWork.MediaFoundation), filename);
+                            source = new CachedTextureFrameSource(CompositorLayer.GraphicsDevice, VideoFrameWorks.GetFramework(FrameWork.MediaFoundation), repaired);
                         }
 
                         source.BounceRepeat = ApplicationProfileSettings.Instance.PilotProfileBoomerangRepeat;

--- a/UI/Nodes/PilotProfileNode.cs
+++ b/UI/Nodes/PilotProfileNode.cs
@@ -167,7 +167,7 @@ namespace UI.Nodes
                 string repaired = System.Text.RegularExpressions.Regex.Replace(filename, @"[^\w\-. \/\\:]", "");
 
                 // Photo paths are stored relative to the working directory.
-                repaired = IOTools.Resolve(repaired);
+                repaired = IOTools.ResolveFromWorkingDirectory(repaired);
 
                 FileInfo fileInfo = new FileInfo(repaired);
                 if (fileInfo.Exists)

--- a/UI/Nodes/Rounds/EventRaceNode.cs
+++ b/UI/Nodes/Rounds/EventRaceNode.cs
@@ -309,22 +309,7 @@ namespace UI.Nodes.Rounds
                 mm.AddSubmenu("Set Race Bracket", SetBracket, Enum.GetValues(typeof(Brackets)).OfType<Brackets>().ToArray());
                 mm.AddItem("Open Race Folder", () =>
                 {
-                    // Use the same logic as the HTTP service to find the events folder
-                    string eventsPath = ApplicationProfileSettings.Instance.EventStorageLocation;
-
-                    if (eventsPath.EndsWith("/"))
-                    {
-                        eventsPath = eventsPath.Substring(0, eventsPath.Length - 1);
-                    }
-
-                    if (string.IsNullOrEmpty(eventsPath))
-                    {
-                        eventsPath = Path.Combine(IOTools.WorkingDirectory?.FullName ?? "", "events");
-                    }
-                    else if (!Path.IsPathRooted(eventsPath))
-                    {
-                        eventsPath = Path.Combine(IOTools.WorkingDirectory?.FullName ?? "", eventsPath);
-                    }
+                    string eventsPath = ApplicationProfileSettings.Instance.EventStoragePath;
 
                     string racePath = Path.Combine(eventsPath, EventManager.EventId.ToString(), Race.ID.ToString());
                     PlatformTools.OpenFileManager(racePath);

--- a/UI/Video/Info.cs
+++ b/UI/Video/Info.cs
@@ -55,7 +55,7 @@ namespace UI.Video
 
         public RecodingInfo(ICaptureFrameSource captureFrameSource)
         {
-            FilePath = IOTools.Relativize(captureFrameSource.Filename);
+            FilePath = IOTools.RelativiseToWorkingDirectory(captureFrameSource.Filename);
             ChannelCoveragePercent = captureFrameSource.VideoConfig.ChannelCoveragePercent;
             FrameTimes = captureFrameSource.FrameTimes.ToArray();
             ChannelBounds = captureFrameSource.VideoConfig.VideoBounds;

--- a/UI/Video/Info.cs
+++ b/UI/Video/Info.cs
@@ -55,7 +55,7 @@ namespace UI.Video
 
         public RecodingInfo(ICaptureFrameSource captureFrameSource)
         {
-            FilePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), captureFrameSource.Filename);
+            FilePath = IOTools.Relativize(captureFrameSource.Filename);
             ChannelCoveragePercent = captureFrameSource.VideoConfig.ChannelCoveragePercent;
             FrameTimes = captureFrameSource.FrameTimes.ToArray();
             ChannelBounds = captureFrameSource.VideoConfig.VideoBounds;

--- a/UI/Video/PhotoBoothNode.cs
+++ b/UI/Video/PhotoBoothNode.cs
@@ -54,7 +54,7 @@ namespace UI.Video
             this.eventManager = eventManager;
             this.soundManager = soundManager;
 
-            PilotsDirectory = new DirectoryInfo(IOTools.Resolve("pilots"));
+            PilotsDirectory = new DirectoryInfo(IOTools.ResolveFromWorkingDirectory("pilots"));
             Timeout = TimeSpan.FromSeconds(10);
         }
 
@@ -463,7 +463,7 @@ namespace UI.Video
 
             if (!string.IsNullOrEmpty(existingFilename))
             {
-                existingPhoto = new FileInfo(IOTools.Resolve(existingFilename));
+                existingPhoto = new FileInfo(IOTools.ResolveFromWorkingDirectory(existingFilename));
             }
             newPhoto = new FileInfo(newFilename);
 
@@ -508,7 +508,7 @@ namespace UI.Video
 
                 newPhoto.MoveTo(newFileName.FullName);
 
-                pilot.PhotoPath = IOTools.Relativize(newFileName.FullName);
+                pilot.PhotoPath = IOTools.RelativiseToWorkingDirectory(newFileName.FullName);
                 pilot.VideoFlipped = videoFlipped;
                 pilot.VideoMirrored = videoMirrored;
                 using (IDatabase db = DatabaseFactory.Open(eventId))

--- a/UI/Video/PhotoBoothNode.cs
+++ b/UI/Video/PhotoBoothNode.cs
@@ -142,8 +142,9 @@ namespace UI.Video
 
             string filenameSafe = Maths.SafeFileNameFromString(Pilot.Name + "_temp.png");
 
+            // Kept absolute: everything downstream does file IO with it, and it is only
+            // made relative to the working directory when it is stored on the pilot.
             string newPath = Path.Combine(PilotsDirectory.FullName, filenameSafe);
-            newPath = Path.GetRelativePath(Directory.GetCurrentDirectory(), newPath);
             camNode.FrameNode.SaveImage(newPath);
 
             if (File.Exists(newPath))
@@ -462,7 +463,7 @@ namespace UI.Video
 
             if (!string.IsNullOrEmpty(existingFilename))
             {
-                existingPhoto = new FileInfo(existingFilename);
+                existingPhoto = new FileInfo(IOTools.Resolve(existingFilename));
             }
             newPhoto = new FileInfo(newFilename);
 
@@ -507,7 +508,7 @@ namespace UI.Video
 
                 newPhoto.MoveTo(newFileName.FullName);
 
-                pilot.PhotoPath = Path.GetRelativePath(Directory.GetCurrentDirectory(), newFileName.FullName);
+                pilot.PhotoPath = IOTools.Relativize(newFileName.FullName);
                 pilot.VideoFlipped = videoFlipped;
                 pilot.VideoMirrored = videoMirrored;
                 using (IDatabase db = DatabaseFactory.Open(eventId))

--- a/UI/Video/PhotoBoothNode.cs
+++ b/UI/Video/PhotoBoothNode.cs
@@ -54,7 +54,7 @@ namespace UI.Video
             this.eventManager = eventManager;
             this.soundManager = soundManager;
 
-            PilotsDirectory = new DirectoryInfo("pilots");
+            PilotsDirectory = new DirectoryInfo(IOTools.Resolve("pilots"));
             Timeout = TimeSpan.FromSeconds(10);
         }
 

--- a/UI/Video/VideoManager.cs
+++ b/UI/Video/VideoManager.cs
@@ -881,7 +881,10 @@ namespace UI.Video
                                 if (source.FrameTimes != null && source.FrameTimes.Any())
                                 {
                                     RecodingInfo vi = new RecodingInfo(source);
-                                    FileInfo videoFile = new FileInfo(vi.FilePath);
+                                    // FilePath is stored relative to the working directory, so it
+                                    // has to be resolved before the .recordinfo.xml is placed
+                                    // next to the video file.
+                                    FileInfo videoFile = new FileInfo(IOTools.Resolve(vi.FilePath));
                                     FileInfo recordingInfo = GetRecordingInfoFileName(videoFile);
                                     IOTools.Write(recordingInfo.Directory.FullName, recordingInfo.Name, vi);
                                     needsVideoInfoWrite.Remove((FrameSource)source);

--- a/UI/Video/VideoManager.cs
+++ b/UI/Video/VideoManager.cs
@@ -884,7 +884,7 @@ namespace UI.Video
                                     // FilePath is stored relative to the working directory, so it
                                     // has to be resolved before the .recordinfo.xml is placed
                                     // next to the video file.
-                                    FileInfo videoFile = new FileInfo(IOTools.Resolve(vi.FilePath));
+                                    FileInfo videoFile = new FileInfo(IOTools.ResolveFromWorkingDirectory(vi.FilePath));
                                     FileInfo recordingInfo = GetRecordingInfoFileName(videoFile);
                                     IOTools.Write(recordingInfo.Directory.FullName, recordingInfo.Name, vi);
                                     needsVideoInfoWrite.Remove((FrameSource)source);

--- a/UI/Video/VideoSourceEditor.cs
+++ b/UI/Video/VideoSourceEditor.cs
@@ -40,7 +40,7 @@ namespace UI.Video
 
         public static VideoSourceEditor GetVideoSourceEditor(EventManager em, Profile profile)
         {
-            VideoManager videoManager = new VideoManager(ApplicationProfileSettings.Instance.EventStorageLocation, profile);
+            VideoManager videoManager = new VideoManager(ApplicationProfileSettings.Instance.EventStoragePath, profile);
 
             videoManager.LoadDevices();
             videoManager.MaintainConnections = true;

--- a/Webb/EventWebServer.cs
+++ b/Webb/EventWebServer.cs
@@ -43,7 +43,7 @@ namespace Webb
 
         public EventWebServer(EventManager eventManager, SoundManager soundManager, IRaceControl raceControl, IEnumerable<Tools.ToolColor> channelColors, string eventStorageLocation = null)
         {
-            CSSStyleSheet = new FileInfo(Path.Combine("httpfiles", "style.css"));
+            CSSStyleSheet = new FileInfo(IOTools.Resolve(Path.Combine("httpfiles", "style.css")));
             this.eventManager = eventManager;
             this.soundManager = soundManager;
             this.raceControl = raceControl;
@@ -247,9 +247,12 @@ namespace Webb
             }
 
 
-            FileInfo file = new FileInfo(Path.Combine(requestPath));
+            FileInfo file = new FileInfo(IOTools.Resolve(Path.Combine(requestPath)));
 
 #if DEBUG
+            // Deliberately left relative to the current directory: this walks up out of the
+            // build output into the source tree, so it must not be resolved against
+            // WorkingDirectory.
             string[] basehttpFilesDir = new string[] { "..", "..", "..", "..", "..", "..", "..","FPVTracksideCore","Webb" };
 
             string combined = Path.Combine(Path.Combine(basehttpFilesDir), Path.Combine(requestPath));
@@ -264,7 +267,7 @@ namespace Webb
             if (!file.Exists)
             {
                 requestPath = new string[] { "httpfiles", "index.html" };
-                file = new FileInfo(Path.Combine(requestPath));
+                file = new FileInfo(IOTools.Resolve(Path.Combine(requestPath)));
                 if (!file.Exists)
                 {
                     return new byte[0];

--- a/Webb/EventWebServer.cs
+++ b/Webb/EventWebServer.cs
@@ -43,7 +43,7 @@ namespace Webb
 
         public EventWebServer(EventManager eventManager, SoundManager soundManager, IRaceControl raceControl, IEnumerable<Tools.ToolColor> channelColors, string eventStorageLocation = null)
         {
-            CSSStyleSheet = new FileInfo(IOTools.Resolve(Path.Combine("httpfiles", "style.css")));
+            CSSStyleSheet = new FileInfo(IOTools.ResolveFromWorkingDirectory("httpfiles", "style.css"));
             this.eventManager = eventManager;
             this.soundManager = soundManager;
             this.raceControl = raceControl;
@@ -247,7 +247,7 @@ namespace Webb
             }
 
 
-            FileInfo file = new FileInfo(IOTools.Resolve(Path.Combine(requestPath)));
+            FileInfo file = new FileInfo(IOTools.ResolveFromWorkingDirectory(requestPath));
 
 #if DEBUG
             // Deliberately left relative to the current directory: this walks up out of the
@@ -267,7 +267,7 @@ namespace Webb
             if (!file.Exists)
             {
                 requestPath = new string[] { "httpfiles", "index.html" };
-                file = new FileInfo(IOTools.Resolve(Path.Combine(requestPath)));
+                file = new FileInfo(IOTools.ResolveFromWorkingDirectory(requestPath));
                 if (!file.Exists)
                 {
                     return new byte[0];

--- a/ffmpegMediaPlatform/FfmpegRtmpFrameSource.cs
+++ b/ffmpegMediaPlatform/FfmpegRtmpFrameSource.cs
@@ -137,7 +137,7 @@ namespace FfmpegMediaPlatform
 
         private byte[] LoadTestPattern(int width, int height)
         {
-            string path = Tools.IOTools.Resolve(System.IO.Path.Combine("img", "testpattern.png"));
+            string path = Tools.IOTools.ResolveFromWorkingDirectory("img", "testpattern.png");
             if (!System.IO.File.Exists(path))
                 return null;
 

--- a/ffmpegMediaPlatform/FfmpegRtmpFrameSource.cs
+++ b/ffmpegMediaPlatform/FfmpegRtmpFrameSource.cs
@@ -137,7 +137,7 @@ namespace FfmpegMediaPlatform
 
         private byte[] LoadTestPattern(int width, int height)
         {
-            string path = System.IO.Path.Combine("img", "testpattern.png");
+            string path = Tools.IOTools.Resolve(System.IO.Path.Combine("img", "testpattern.png"));
             if (!System.IO.File.Exists(path))
                 return null;
 


### PR DESCRIPTION
Fixes #25.

### The problem

On macOS `MacPlatformTools` establishes two different roots: `WorkingDirectory`
(`~/Documents/FPVTrackside`) and the process current directory, which is pinned to
the `.app` bundle via `Directory.SetCurrentDirectory(baseDirectory)`.

The "Open Directory" menus already resolve against `WorkingDirectory`:

```csharp
// MenuButton.OpenCurrentDirectory
path = IOTools.WorkingDirectory?.FullName ?? "";
```

but the code that actually stores the data still used bare relative paths, which
resolve against the current directory - so the data was written inside the bundle:

```csharp
new DirectoryInfo(ApplicationProfileSettings.Instance.EventStorageLocation) // "events"
new DirectoryInfo("Tracks")
new DirectoryInfo("pilots")
```

The menus therefore ask Finder to open directories that do not exist.
`Process.Start("open", ...)` fails quietly, so nothing happens on screen.

| Menu item | Opens | Data actually lives in | Result |
|---|---|---|---|
| Open Event Data Directory | `~/Documents/FPVTrackside/events/<id>` | bundle | missing - nothing happens |
| Open Events Directory | `~/Documents/FPVTrackside/events` | bundle | missing - nothing happens |
| Open Tracks Directory | `~/Documents/FPVTrackside/Tracks` | bundle | missing - nothing happens |
| Open Pilot Profile Image Directory | `~/Documents/FPVTrackside/pilots` | bundle | opens, but empty |
| Open FPVTrackside Directory | `~/Documents/FPVTrackside` | same | works |

That accounts for the four broken entries in the submenu. The race folder in the
race right-click menu resolves under `events` too, so it fails for the same reason.

Windows is unaffected because there the current directory *is* the working
directory, which is why this never showed up outside macOS. Linux has the same
split as macOS.

### The change

`IOTools.Resolve` / `IOTools.Relativize` are added as the single place where a
stored relative path becomes an absolute one, and the paths that were bare
relative strings now go through it. Nothing about the stored settings changes -
`EventStorageLocation` stays relative so it remains portable between machines -
only where it is resolved.

- Event storage, `Tracks`, `pilots`, `httpfiles`, `formats`, `img`, `sounds` and
  the script/sheet lookups resolve against `WorkingDirectory`
- Pilot photos and recordings are stored and read on one base, so the profile
  image directory is no longer empty
- The low-disk-space check measures the volume that holds the data rather than
  the one holding the `.app`
- `IOTools.Resolve` hands back anything that is not a usable path (a URL, or
  characters the platform rejects) untouched, so callers fail exactly as before