### PR TITLE
Honour the TTS speed setting on macOS and Linux

### DIFF
--- a/FPVMacSideCore/MacSpeaker.cs
+++ b/FPVMacSideCore/MacSpeaker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,7 +11,17 @@ namespace FPVMacsideCore
 {
     public class MacSpeaker : ISpeaker
     {
+        // 'say' takes an absolute words-per-minute value, so map the -10 to 10
+        // scale onto a nominal 175wpm, doubling at 10 and halving at -10.
+        // Note that macOS clamps slow speech - anything under about 150wpm gets
+        // pulled back up - so negative rates have far less effect than positive
+        // ones. That's the speech engine's doing, not this mapping.
+        private const double BaseWordsPerMinute = 175;
+
         private string voice;
+
+        // 0 means leave the rate alone and let the voice use its own default.
+        private int wordsPerMinute;
 
         private Process speechProcess;
 
@@ -35,6 +46,13 @@ namespace FPVMacsideCore
 
         public void SetRate(int rate)
         {
+            if (rate == 0)
+            {
+                wordsPerMinute = 0;
+                return;
+            }
+
+            wordsPerMinute = (int)Math.Round(BaseWordsPerMinute * Math.Pow(2, rate / 10.0));
         }
 
         public void SetVolume(int volume)
@@ -43,8 +61,17 @@ namespace FPVMacsideCore
 
         public void Speak(string text)
         {
-            string cmdArgs = text;
-            speechProcess = Process.Start("/usr/bin/say", cmdArgs);
+            ProcessStartInfo psi = new ProcessStartInfo("/usr/bin/say");
+
+            if (wordsPerMinute > 0)
+            {
+                psi.ArgumentList.Add("-r");
+                psi.ArgumentList.Add(wordsPerMinute.ToString(CultureInfo.InvariantCulture));
+            }
+
+            psi.ArgumentList.Add(text);
+
+            speechProcess = Process.Start(psi);
             speechProcess.WaitForExit();
             speechProcess = null;
         }

--- a/FPVTuxSideCore/TuxSpeaker.cs
+++ b/FPVTuxSideCore/TuxSpeaker.cs
@@ -1,10 +1,18 @@
 using System.Diagnostics;
+using System.Globalization;
 using Tools;
 
 namespace FPVTuxsideCore
 {
     public class TuxSpeaker : ISpeaker
     {
+        // espeak-ng takes an absolute words-per-minute value, so map the -10 to
+        // 10 scale onto a nominal 175wpm, doubling at 10 and halving at -10.
+        private const double BaseWordsPerMinute = 175;
+
+        // 0 means leave the rate alone and let espeak-ng use its own default.
+        private int wordsPerMinute;
+
         private Process speechProcess;
 
         public void Dispose()
@@ -19,13 +27,29 @@ namespace FPVTuxsideCore
 
         public void SelectVoice(string voice) { }
 
-        public void SetRate(int rate) { }
+        public void SetRate(int rate)
+        {
+            if (rate == 0)
+            {
+                wordsPerMinute = 0;
+                return;
+            }
+
+            wordsPerMinute = (int)Math.Round(BaseWordsPerMinute * Math.Pow(2, rate / 10.0));
+        }
 
         public void SetVolume(int volume) { }
 
         public void Speak(string text)
         {
             var psi = new ProcessStartInfo("espeak-ng");
+
+            if (wordsPerMinute > 0)
+            {
+                psi.ArgumentList.Add("-s");
+                psi.ArgumentList.Add(wordsPerMinute.ToString(CultureInfo.InvariantCulture));
+            }
+
             psi.ArgumentList.Add(text);
             speechProcess = Process.Start(psi);
             speechProcess.WaitForExit();


### PR DESCRIPTION
## The problem

The per-sound **"TTS speed (-10 to 10)"** setting (`Sound.Rate`) does nothing on macOS or Linux.

The value is plumbed correctly the whole way down:

```
Sound.Rate  ->  SpeechRequest(..., sound.Rate, ...)   SoundManager.cs:807
            ->  speaker.SetRate(clamp(-10, 10))       SpeechManager.cs:143
            ->  MacSpeaker.SetRate(int rate)          <- empty method body
```

`MacSpeaker.SetRate` and `TuxSpeaker.SetRate` were both `{ }`, so the value arrived and was discarded. Only `WindowsSpeaker` implemented it (via SAPI). The setting saves to `Sounds.xml` and reloads correctly, which makes it look like it's working.

## The fix

Both platforms shell out to a binary that takes an absolute words-per-minute value — `say -r` and `espeak-ng -s` — so `SetRate` maps the -10..10 scale onto a nominal 175wpm, doubling at +10 and halving at -10:

```csharp
wordsPerMinute = (int)Math.Round(BaseWordsPerMinute * Math.Pow(2, rate / 10.0));
```

| setting | wpm |
|---:|---:|
| -10 | 88 |
| -5 | 124 |
| **0** | **flag omitted** |
| +5 | 247 |
| +10 | 350 |

**A rate of 0 omits the flag entirely** rather than passing `-r 175`, so each voice keeps its own natural default and behaviour is byte-identical to before for anyone who hasn't touched the setting.

175 is not a guess — on macOS, `say -r 175` and `say` with no flag produce audio of identical duration (`5.440544s` for the same sentence), so the scale is anchored on the real default.

Measured on macOS, same sentence rendered with `say -o` and timed with `afinfo`:

| rate | duration |
|---:|---:|
| 0 (default) | 5.44 s |
| +5 | 4.02 s |
| +10 | 2.98 s |

## Also

`MacSpeaker.Speak` passed the text to `Process.Start(fileName, arguments)` as a single argument string, which .NET then re-parses for quotes — a pilot name containing `"` would have been mangled. It now uses `ProcessStartInfo.ArgumentList`, matching what `TuxSpeaker` already did, which was needed anyway to add the flag cleanly.

## Two caveats

**macOS clamps slow speech.** Requested vs. effective rate, measured:

| requested | effective |
|---:|---:|
| 10 wpm | ~115 wpm |
| 50 wpm | ~133 wpm |
| 88 wpm | ~144 wpm |
| 175 wpm | 175 wpm |

Asking for 10wpm yields only ~1.5x slower. Increases are honoured faithfully; large decreases are not. That's the speech engine's behaviour, not the mapping, and it's noted in a comment. I deliberately did **not** skew the negative half to compensate, since `espeak-ng` honours its full 80–450 range properly and skewing it would make Linux wrong to paper over a macOS quirk.

**The Linux change is untested on hardware** — I don't have a box to try it on. It compiles clean and `-s <wpm>` is the correct `espeak-ng` flag, but it deserves a look from someone who can run it.

`SetVolume` and `SelectVoice` are still empty stubs on both platforms. Left out to keep this to one concern; happy to follow up.

## Testing

Sound editor -> select a sound -> change **TTS speed** -> **Play**. The editor binds to the live `Sound` objects and `SetRate` runs before every utterance, so it takes effect immediately without OK or a restart. Verified 0 -> +10 is clearly faster and 0 sounds unchanged.