### PR TITLE
Honour the TTS volume setting on macOS and Linux

### DIFF
--- a/FPVMacSideCore/MacSpeaker.cs
+++ b/FPVMacSideCore/MacSpeaker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,7 +11,17 @@ namespace FPVMacsideCore
 {
     public class MacSpeaker : ISpeaker
     {
+        // 'say' takes an absolute words-per-minute value, so map the -10 to 10
+        // scale onto a nominal 175wpm, doubling at 10 and halving at -10.
+        // Note that macOS clamps slow speech - anything under about 150wpm gets
+        // pulled back up - so negative rates have far less effect than positive
+        // ones. That's the speech engine's doing, not this mapping.
+        private const double BaseWordsPerMinute = 175;
+
         private string voice;
+
+        // 0 means leave the rate alone and let the voice use its own default.
+        private int wordsPerMinute;
 
         private Process speechProcess;
 
@@ -35,6 +46,13 @@ namespace FPVMacsideCore
 
         public void SetRate(int rate)
         {
+            if (rate == 0)
+            {
+                wordsPerMinute = 0;
+                return;
+            }
+
+            wordsPerMinute = (int)Math.Round(BaseWordsPerMinute * Math.Pow(2, rate / 10.0));
         }
 
         public void SetVolume(int volume)
@@ -43,8 +61,17 @@ namespace FPVMacsideCore
 
         public void Speak(string text)
         {
-            string cmdArgs = text;
-            speechProcess = Process.Start("/usr/bin/say", cmdArgs);
+            ProcessStartInfo psi = new ProcessStartInfo("/usr/bin/say");
+
+            if (wordsPerMinute > 0)
+            {
+                psi.ArgumentList.Add("-r");
+                psi.ArgumentList.Add(wordsPerMinute.ToString(CultureInfo.InvariantCulture));
+            }
+
+            psi.ArgumentList.Add(text);
+
+            speechProcess = Process.Start(psi);
             speechProcess.WaitForExit();
             speechProcess = null;
         }

--- a/FPVMacSideCore/MacSpeaker.cs
+++ b/FPVMacSideCore/MacSpeaker.cs
@@ -23,6 +23,10 @@ namespace FPVMacsideCore
         // 0 means leave the rate alone and let the voice use its own default.
         private int wordsPerMinute;
 
+        // 1 is the voice's normal level, and emitting nothing at all produces
+        // byte-identical audio, so only attenuate when asked to.
+        private double volumeScale = 1;
+
         private Process speechProcess;
 
         public MacSpeaker()
@@ -55,8 +59,13 @@ namespace FPVMacsideCore
             wordsPerMinute = (int)Math.Round(BaseWordsPerMinute * Math.Pow(2, rate / 10.0));
         }
 
+        // 'say' has no volume flag, so attenuation goes through an embedded
+        // [[volm]] command instead. Its scale is logarithmic - amplitude halves
+        // every 0.25 - which puts a straight percentage close to linear in
+        // perceived loudness.
         public void SetVolume(int volume)
         {
+            volumeScale = Math.Clamp(volume, 0, 100) / 100.0;
         }
 
         public void Speak(string text)
@@ -67,6 +76,11 @@ namespace FPVMacsideCore
             {
                 psi.ArgumentList.Add("-r");
                 psi.ArgumentList.Add(wordsPerMinute.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (volumeScale < 1)
+            {
+                text = string.Format(CultureInfo.InvariantCulture, "[[volm {0:0.###}]] {1}", volumeScale, text);
             }
 
             psi.ArgumentList.Add(text);

--- a/FPVTuxSideCore/TuxSpeaker.cs
+++ b/FPVTuxSideCore/TuxSpeaker.cs
@@ -1,10 +1,18 @@
 using System.Diagnostics;
+using System.Globalization;
 using Tools;
 
 namespace FPVTuxsideCore
 {
     public class TuxSpeaker : ISpeaker
     {
+        // espeak-ng takes an absolute words-per-minute value, so map the -10 to
+        // 10 scale onto a nominal 175wpm, doubling at 10 and halving at -10.
+        private const double BaseWordsPerMinute = 175;
+
+        // 0 means leave the rate alone and let espeak-ng use its own default.
+        private int wordsPerMinute;
+
         private Process speechProcess;
 
         public void Dispose()
@@ -19,13 +27,29 @@ namespace FPVTuxsideCore
 
         public void SelectVoice(string voice) { }
 
-        public void SetRate(int rate) { }
+        public void SetRate(int rate)
+        {
+            if (rate == 0)
+            {
+                wordsPerMinute = 0;
+                return;
+            }
+
+            wordsPerMinute = (int)Math.Round(BaseWordsPerMinute * Math.Pow(2, rate / 10.0));
+        }
 
         public void SetVolume(int volume) { }
 
         public void Speak(string text)
         {
             var psi = new ProcessStartInfo("espeak-ng");
+
+            if (wordsPerMinute > 0)
+            {
+                psi.ArgumentList.Add("-s");
+                psi.ArgumentList.Add(wordsPerMinute.ToString(CultureInfo.InvariantCulture));
+            }
+
             psi.ArgumentList.Add(text);
             speechProcess = Process.Start(psi);
             speechProcess.WaitForExit();

--- a/FPVTuxSideCore/TuxSpeaker.cs
+++ b/FPVTuxSideCore/TuxSpeaker.cs
@@ -13,6 +13,10 @@ namespace FPVTuxsideCore
         // 0 means leave the rate alone and let espeak-ng use its own default.
         private int wordsPerMinute;
 
+        // espeak-ng's default amplitude is 100, so a full-volume request needs
+        // no flag at all.
+        private int amplitude = 100;
+
         private Process speechProcess;
 
         public void Dispose()
@@ -38,7 +42,10 @@ namespace FPVTuxsideCore
             wordsPerMinute = (int)Math.Round(BaseWordsPerMinute * Math.Pow(2, rate / 10.0));
         }
 
-        public void SetVolume(int volume) { }
+        public void SetVolume(int volume)
+        {
+            amplitude = Math.Clamp(volume, 0, 100);
+        }
 
         public void Speak(string text)
         {
@@ -48,6 +55,12 @@ namespace FPVTuxsideCore
             {
                 psi.ArgumentList.Add("-s");
                 psi.ArgumentList.Add(wordsPerMinute.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (amplitude < 100)
+            {
+                psi.ArgumentList.Add("-a");
+                psi.ArgumentList.Add(amplitude.ToString(CultureInfo.InvariantCulture));
             }
 
             psi.ArgumentList.Add(text);


### PR DESCRIPTION
> **Stacked on #73.** Both changes edit `Speak()` in the same two files, so branching them independently would have produced a merge conflict. Once #73 merges, only the volume commit will show here. Happy to rebase into a standalone PR if you'd rather take this one first.

## The problem

Same shape as #73, one method along. `MacSpeaker.SetVolume` and `TuxSpeaker.SetVolume` were both `{ }`.

That kills **two** settings on macOS and Linux, because `SpeechManager` multiplies them together before handing the result to the speaker (`SpeechManager.cs:145-147`):

```csharp
float factorVolume = (request.Volume / 100.0f) * (Volume / 100.0f);
speaker.SetVolume(Math.Clamp((int)(factorVolume * 100), 0, 100));
```

- the per-sound **"Volume (0 to 100)"** in the sound editor
- the global **"Text to speech Volume (0 - 100)"** in application settings

Both save and reload correctly, so they look functional.

## The fix

`espeak-ng` has `-a <amplitude>`, whose default is 100, so the setting maps to it 1:1.

`say` has no volume flag at all, so attenuation goes through an embedded `[[volm]]` command prefixed to the text.

**In both cases a full-volume request emits nothing**, so anyone who hasn't touched the setting gets byte-identical output. Measured peak amplitude, macOS, same sentence:

| volume | emitted | peak |
|---:|---|---:|
| 100 | *(nothing)* | 25080 |
| 75 | `[[volm 0.75]]` | 12540 |
| 50 | `[[volm 0.5]]` | 6270 |
| 33 | `[[volm 0.33]]` | 3885 |
| 10 | `[[volm 0.1]]` | 2086 |
| 0 | `[[volm 0]]` | 0 |

`[[volm 1.0]]` and no command at all both measure 25080 exactly, which is why the full-volume case skips it.

Worth noting `volm` is logarithmic — amplitude halves every 0.25 step. I mapped the percentage straight onto it rather than correcting to match SAPI's linear-amplitude scale, because loudness perception is roughly logarithmic too, so a straight percentage ends up closer to linear in *perceived* loudness. It's noted in a comment.

## One thing worth a look

The `[[volm]]` value is formatted with `CultureInfo.InvariantCulture`. Without it, a comma-decimal locale emits `[[volm 0,5]]`, which `say` does not recognise as a command and **reads out loud instead** — measured 2.95s versus 1.28s for the same sentence. So on a Spanish or German system every callout would have announced "volm 0,5" before the pilot's name.

## Caveats

- **The Linux side is untested on hardware**, same as #73. It compiles clean and `-a` is the correct `espeak-ng` flag, but someone with a box should confirm.
- `SelectVoice` is still an empty stub on both platforms. I'm leaving it out deliberately: `MacPlatformTools.CreateSpeaker(string voice)` currently discards its parameter, and `ApplicationProfileSettings` defaults `Voice` to `"Microsoft Zira Desktop"`. Every existing Mac profile has that Windows voice name saved, and `say -v "Microsoft Zira Desktop"` fails with `-241`. Honouring the parameter without a validation and fallback path would break speech entirely for existing users on upgrade, so it needs its own change.

## Testing

Sound editor -> select a sound -> change **Volume** -> **Play**. Takes effect immediately, no OK or restart, since `SetVolume` runs before every utterance. Verified 100 / 25 / 0 and back to 100.