### PR TITLE
Match pilot profile pictures against macOS-decomposed file names

### DIFF
--- a/RaceLib/ProfilePictures.cs
+++ b/RaceLib/ProfilePictures.cs
@@ -66,8 +66,8 @@ namespace RaceLib
                             // macOS stores file names decomposed (NFD), so both sides are
                             // brought to NFC before comparing. The matched FileInfo keeps
                             // the on-disk name for the actual file access.
-                            string pilotName = Maths.NormalizeUnicode(p.Name).ToLower();
-                            IEnumerable<FileInfo> matches = media.Where(f => Maths.NormalizeUnicode(f.Name).ToLower().Contains(pilotName));
+                            string pilotName = p.Name.NormaliseUnicode().ToLower();
+                            IEnumerable<FileInfo> matches = media.Where(f => f.Name.NormaliseUnicode().ToLower().Contains(pilotName));
                             if (matches.Any())
                             {
                                 p.PhotoPath = matches.OrderByDescending(f => listOfExt.IndexOf(f.Extension)).FirstOrDefault().FullName;
@@ -87,7 +87,7 @@ namespace RaceLib
                     {
                         if (p.PhotoPath == null)
                         {
-                            Patreon match = patreonWithHandle.FirstOrDefault(pa => Maths.NormalizeUnicode(pa.Handle).ToLower() == Maths.NormalizeUnicode(p.Name).ToLower());
+                            Patreon match = patreonWithHandle.FirstOrDefault(pa => pa.Handle.NormaliseUnicode().ToLower() == p.Name.NormaliseUnicode().ToLower());
                             if (match != null)
                             {
                                 p.PhotoPath = match.ThumbFilename;

--- a/RaceLib/ProfilePictures.cs
+++ b/RaceLib/ProfilePictures.cs
@@ -63,7 +63,11 @@ namespace RaceLib
                         string oldPath = p.PhotoPath;
                         if (string.IsNullOrEmpty(p.PhotoPath))
                         {
-                            IEnumerable<FileInfo> matches = media.Where(f => f.Name.ToLower().Contains(p.Name.ToLower()));
+                            // macOS stores file names decomposed (NFD), so both sides are
+                            // brought to NFC before comparing. The matched FileInfo keeps
+                            // the on-disk name for the actual file access.
+                            string pilotName = Maths.NormalizeUnicode(p.Name).ToLower();
+                            IEnumerable<FileInfo> matches = media.Where(f => Maths.NormalizeUnicode(f.Name).ToLower().Contains(pilotName));
                             if (matches.Any())
                             {
                                 p.PhotoPath = matches.OrderByDescending(f => listOfExt.IndexOf(f.Extension)).FirstOrDefault().FullName;
@@ -83,7 +87,7 @@ namespace RaceLib
                     {
                         if (p.PhotoPath == null)
                         {
-                            Patreon match = patreonWithHandle.FirstOrDefault(pa => pa.Handle.ToLower() == p.Name.ToLower());
+                            Patreon match = patreonWithHandle.FirstOrDefault(pa => Maths.NormalizeUnicode(pa.Handle).ToLower() == Maths.NormalizeUnicode(p.Name).ToLower());
                             if (match != null)
                             {
                                 p.PhotoPath = match.ThumbFilename;

--- a/Tools/Ext.cs
+++ b/Tools/Ext.cs
@@ -230,6 +230,32 @@ namespace Tools
             else
                 dict.Add(key, value);
         }
+
+        /// <summary>
+        /// Brings text to composed unicode form (NFC) so that names read from the file
+        /// system compare equal to the same text typed by the user. macOS stores file
+        /// names decomposed (NFD / UTF-8-MAC): a decomposed dakuten and a composed one
+        /// are different strings, and a compatibility ideograph (U+FA10 塚) differs from
+        /// its canonical form (U+585A 塚). NFC unifies both. Use for comparison and for
+        /// text that becomes data (e.g. a pilot name derived from a file name) - not for
+        /// paths used in file IO, where the on-disk bytes must be preserved for the
+        /// byte-exact file systems on Windows and Linux.
+        /// </summary>
+        public static string NormaliseUnicode(this string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            try
+            {
+                return text.Normalize(NormalizationForm.FormC);
+            }
+            catch (ArgumentException)
+            {
+                // Invalid surrogate pairs - keep the original.
+                return text;
+            }
+        }
     }
 
     public class DateOnlyAttribute : Attribute

--- a/Tools/Maths.cs
+++ b/Tools/Maths.cs
@@ -339,5 +339,31 @@ namespace Tools
             Regex rgx = new Regex("[^a-zA-Z0-9 _.-]");
             return rgx.Replace(filename, "_");
         }
+
+        /// <summary>
+        /// Brings text to composed unicode form (NFC) so that names read from the file
+        /// system compare equal to the same text typed by the user. macOS stores file
+        /// names decomposed (NFD / UTF-8-MAC): a decomposed dakuten and a composed one
+        /// are different strings, and a compatibility ideograph (U+FA10 塚) differs from
+        /// its canonical form (U+585A 塚). NFC unifies both. Use for comparison and for
+        /// text that becomes data (e.g. a pilot name derived from a file name) - not for
+        /// paths used in file IO, where the on-disk bytes must be preserved for the
+        /// byte-exact file systems on Windows and Linux.
+        /// </summary>
+        public static string NormalizeUnicode(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            try
+            {
+                return text.Normalize(NormalizationForm.FormC);
+            }
+            catch (ArgumentException)
+            {
+                // Invalid surrogate pairs - keep the original.
+                return text;
+            }
+        }
     }
 }

--- a/Tools/Maths.cs
+++ b/Tools/Maths.cs
@@ -339,31 +339,5 @@ namespace Tools
             Regex rgx = new Regex("[^a-zA-Z0-9 _.-]");
             return rgx.Replace(filename, "_");
         }
-
-        /// <summary>
-        /// Brings text to composed unicode form (NFC) so that names read from the file
-        /// system compare equal to the same text typed by the user. macOS stores file
-        /// names decomposed (NFD / UTF-8-MAC): a decomposed dakuten and a composed one
-        /// are different strings, and a compatibility ideograph (U+FA10 塚) differs from
-        /// its canonical form (U+585A 塚). NFC unifies both. Use for comparison and for
-        /// text that becomes data (e.g. a pilot name derived from a file name) - not for
-        /// paths used in file IO, where the on-disk bytes must be preserved for the
-        /// byte-exact file systems on Windows and Linux.
-        /// </summary>
-        public static string NormalizeUnicode(string text)
-        {
-            if (string.IsNullOrEmpty(text))
-                return text;
-
-            try
-            {
-                return text.Normalize(NormalizationForm.FormC);
-            }
-            catch (ArgumentException)
-            {
-                // Invalid surrogate pairs - keep the original.
-                return text;
-            }
-        }
     }
 }

--- a/UI/Nodes/PilotListNode.cs
+++ b/UI/Nodes/PilotListNode.cs
@@ -268,7 +268,7 @@ namespace UI.Nodes
                 {
                     // The file name becomes the pilot's name, i.e. text rather than a path,
                     // so compose it (macOS file names are decomposed unicode - NFD).
-                    string name = Maths.NormalizeUnicode(fileInfo.Name.Replace(fileInfo.Extension, ""));
+                    string name = fileInfo.Name.Replace(fileInfo.Extension, "").NormaliseUnicode();
                     if (!names.Contains(name))
                     {
                         names.Add(name);

--- a/UI/Nodes/PilotListNode.cs
+++ b/UI/Nodes/PilotListNode.cs
@@ -266,7 +266,9 @@ namespace UI.Nodes
                 List<string> names = new List<string>();
                 foreach (FileInfo fileInfo in eventManager.ProfilePictures.GetPilotProfileMedia())
                 {
-                    string name = fileInfo.Name.Replace(fileInfo.Extension, "");
+                    // The file name becomes the pilot's name, i.e. text rather than a path,
+                    // so compose it (macOS file names are decomposed unicode - NFD).
+                    string name = Maths.NormalizeUnicode(fileInfo.Name.Replace(fileInfo.Extension, ""));
                     if (!names.Contains(name))
                     {
                         names.Add(name);


### PR DESCRIPTION
### The problem

macOS stores file names in decomposed unicode. HFS+ always did, and Finder and other
Foundation-based apps still create NFD (UTF-8-MAC) names on APFS. So a file the user
drops into `pilots/` does not compare equal to the same name typed into the app, which
is composed (NFC).

For a pilot called **Müller**:

| | Code points |
|---|---|
| `Müller` typed into the app (NFC) | `M` `U+00FC` `l` `l` `e` `r` |
| `Müller.jpg` as macOS stores it (NFD) | `M` `u` `U+0308` `l` `l` `e` `r` |

These are different strings, so the profile picture lookup

```csharp
// ProfilePictures.FindProfilePictures
media.Where(f => f.Name.ToLower().Contains(p.Name.ToLower()))
```

silently finds nothing. The pilot gets no photo, with no error to explain why. Same for
**Schröder**, **Jäger**, or any name carrying an umlaut - and for the accented names
common across most of Europe. (`Groß` is unaffected: `ß` has no canonical
decomposition.)

This also bites in a mixed setup, which is the normal case for a race: an event is
created on Windows, where the pilot name is stored composed in the event JSON, and the
photos are added on a Mac, where the file names end up decomposed. The two never match.

Beyond umlauts, the same comparison fails for CJK compatibility ideographs - `U+FA10`
never equals its canonical form `U+585A`, though both display as 塚 - and for Japanese
names with a dakuten, where NFD splits `だ` into `た` + `゙`.

Two other comparisons share the problem: the Patreon handle match, and "Import from
profile picture filenames", where a file name is turned into a pilot's *name* and
stored in the database in whatever form it happened to have on disk.

### The change

`Maths.NormalizeUnicode` composes text to NFC, and it is applied to **both sides of the
comparisons only**:

- the profile picture name match
- the Patreon handle match
- the pilot names produced by "Import from profile picture filenames" - the one place
  where a file name becomes data rather than a path

| File | Change |
|---|---|
| `Tools/Maths.cs` | Add `NormalizeUnicode` - NFC, returns the input unchanged on invalid surrogates |
| `RaceLib/ProfilePictures.cs` | Normalize both sides of the media-file match and the Patreon handle match |
| `UI/Nodes/PilotListNode.cs` | Compose pilot names derived from file names by the import menu |

### Why normalize rather than retry the other form

An alternative would be to try the composed name, then fall back to the decomposed one.
That cannot fix the compatibility-ideograph case: no normalization form regenerates
`U+FA10` from `U+585A`, so a retry on the pilot-name side alone never produces the
string that is on disk. Normalizing the file-name side is what unifies the two, and it
covers the umlaut and dakuten cases in the same step.

### What is deliberately left alone

**File IO is untouched.** The matched `FileInfo` keeps the on-disk name, so the actual
file access still uses the bytes that are really on disk. APFS and HFS+ lookups are
normalization-insensitive, so nothing needs converting to open a file, and the
byte-exact file systems on Windows and Linux keep working with the stored paths
unchanged.

**File names that get written are not normalized either.** NFC is not reversible for
compatibility characters - composing `U+FA10` yields `U+585A`, a different character -
so normalizing on write would rename the user's files. Only text being compared, or
text being turned into data, is composed.

`NormalizeUnicode` returns the input unchanged if `Normalize` throws on an invalid
surrogate pair, so a malformed name degrades to today's behaviour rather than throwing.

Windows and Linux are unaffected in practice: names there are already composed, and NFC
on composed text is a no-op.

### Verification

Ordinal string comparison in .NET, before → after normalization:

| Case | Before | After |
|---|---|---|
| NFD `u` + `U+0308` vs NFC `U+00FC` (umlaut) | not equal | equal |
| NFD `た` + `゙` vs NFC `だ` (dakuten) | not equal | equal |
| `U+FA10` vs `U+585A` (compatibility ideograph) | not equal | equal |
| file `Müller.jpg` (NFD) contains typed `Müller` (NFC) | no | yes |

Built `FPVTrackside - Core.sln` in Release: 0 errors.