### PR TITLE
Bound production log growth

### DIFF
--- a/Tools/Logger.cs
+++ b/Tools/Logger.cs
@@ -13,6 +13,11 @@ namespace Tools
 {
     public class Logger : IDisposable
     {
+#if !DEBUG
+        // One active log plus up to 49 numbered archives (approximately 50 MB).
+        private const int MaximumProductionLogFiles = 50;
+#endif
+        private const long MaximumLogFileSize = 1024 * 1024;
 
         public static Logger UI { get; private set; }
         public static Logger TimingLog { get; private set; }
@@ -174,17 +179,44 @@ namespace Tools
         private void DoSizeCheck()
         {
             FileInfo fi = new FileInfo(filename);
-            if (fi.Exists)
+#if !DEBUG
+            int archiveLimit = MaximumProductionLogFiles - 1;
+            if (fi.Exists && fi.Length > MaximumLogFileSize)
             {
-                if (fi.Length > 1024 * 1024)
+                // Leave a slot for the active log that is about to be archived.
+                archiveLimit--;
+            }
+
+            var archivedLogs = fi.Directory
+                .GetFiles(fi.Name + "*")
+                .Select(file => new
                 {
-                    int counter = 1;
-                    while (File.Exists(fi.FullName + counter))
-                    {
-                        counter++;
-                    }
-                    fi.MoveTo(fi.FullName + counter);
+                    File = file,
+                    Suffix = file.Name.Substring(fi.Name.Length)
+                })
+                .Where(archive => int.TryParse(archive.Suffix, out int index) && index > 0)
+                .OrderByDescending(archive => archive.File.LastWriteTimeUtc)
+                .ToArray();
+
+            foreach (var archivedLog in archivedLogs.Skip(archiveLimit))
+            {
+                archivedLog.File.Delete();
+            }
+#endif
+
+            if (fi.Exists && fi.Length > MaximumLogFileSize)
+            {
+                int counter = 1;
+#if !DEBUG
+                while (counter < MaximumProductionLogFiles && File.Exists(fi.FullName + counter))
+#else
+                while (File.Exists(fi.FullName + counter))
+#endif
+                {
+                    counter++;
                 }
+
+                fi.MoveTo(fi.FullName + counter);
             }
         }
 

--- a/Webb/EventWebServer.cs
+++ b/Webb/EventWebServer.cs
@@ -210,7 +210,9 @@ namespace Webb
                         string[] pathWithoutEvents = requestPath.Skip(1).ToArray(); // Remove "events" from the path
                         string target = Path.Combine(eventsPath, Path.Combine(pathWithoutEvents));
 
+#if DEBUG
                         Logger.HTTP.Log(this, "Request: " + path + " -> Target: " + target + " (EventsPath: " + eventsPath + ")");
+#endif
 
                         if (target == eventsPath || string.IsNullOrEmpty(target))
                             target = eventRoot.FullName;
@@ -224,10 +226,14 @@ namespace Webb
                                 {
                                     context.Response.ContentType = "application/json";
                                 }
+#if DEBUG
                                 Logger.HTTP.Log(this, "Serving file: " + target);
+#endif
                                 return File.ReadAllBytes(target);
                             }
+#if DEBUG
                             Logger.HTTP.Log(this, "File not found: " + target);
+#endif
                             return new byte[0];
                         }
                         else


### PR DESCRIPTION
## Summary

- keep detailed embedded HTTP server request and file-serving traces in Debug builds only
- cap Release logging at 50 rolling files: one active log plus 49 numbered archives
- reuse the oldest archive slot and trim pre-existing excess archives

## Root cause

The embedded HTTP server recorded every event-file request as a Notice in production. Any frequently polling browser, dashboard, or integration could therefore produce logs much faster than expected.

The logger rotated the active file after approximately 1 MB, but always selected a new numbered filename and never removed older archives. Sustained traffic could consequently grow the log directory without a bound.

## How this was discovered

This was first noticed on a race-director Mac while using `dd-pits` with FPVTrackside's embedded server on port 8080. Dashboard integrations such as `dd-pits` or `drone-dashboard` can poll many event files repeatedly, causing every request, successful response, and missing file to be written to the production log.

In the observed run, FPVTrackside rotated an approximately 1.1 MB log every 6–7 seconds. If sustained, that rate could produce roughly 12,000–14,000 rotated files and 13–15 GB of logs per day.

The issue is not specific to either dashboard: any frequently polling client can expose the same unbounded server-side logging behavior.

## Impact

Release builds retain approximately 50 MB of rolling application logs while preserving the newest history. Existing installations with more than 49 numbered archives are trimmed automatically. Detailed per-request diagnostics remain available in Debug builds.

## Validation

- `dotnet build FPVMacSideCore/FPVMacsideCore.csproj -c Debug -m:1 --no-restore`: succeeds with 0 errors
- `dotnet build FPVMacSideCore/FPVMacsideCore.csproj -c Release -m:1 --no-restore`: succeeds with 0 errors
- Release rotation harness seeded 75 legacy archives and stayed at exactly one active log plus 49 archives across 60 additional rotations
- verified the three request-trace strings remain in the Debug assembly and are absent from the Release assembly
