### PR TITLE
feat(racelib): add HDZero Low Band (L1-L8) channels

### DIFF
--- a/RaceLib/Channel.cs
+++ b/RaceLib/Channel.cs
@@ -447,7 +447,8 @@ namespace RaceLib
                     break;
 
                 case Band.LowBand:
-                    return 5333 + ((channel - 1) * 40);
+                    // Matches HDZero VTX V3 firmware L1-L8 (5362, 5399 ... 5621, 37 MHz spacing)
+                    return 5362 + ((channel - 1) * 37);
                 case Band.Diatone:
                     return 5362 + ((channel - 1) * 37);
 

--- a/RaceLib/Channel.cs
+++ b/RaceLib/Channel.cs
@@ -301,7 +301,28 @@ namespace RaceLib
             new Channel(55, 'R', 7, Band.HDZero),
             new Channel(56, 'R', 8, Band.HDZero),
             new Channel(57, 'F', 2, Band.HDZero),
-            new Channel(58, 'F', 4, Band.HDZero)
+            new Channel(58, 'F', 4, Band.HDZero),
+            new Channel(82, 'L', 1, Band.HDZero),
+            new Channel(83, 'L', 2, Band.HDZero),
+            new Channel(84, 'L', 3, Band.HDZero),
+            new Channel(85, 'L', 4, Band.HDZero),
+            new Channel(86, 'L', 5, Band.HDZero),
+            new Channel(87, 'L', 6, Band.HDZero),
+            new Channel(88, 'L', 7, Band.HDZero),
+            new Channel(89, 'L', 8, Band.HDZero)
+        };
+
+        // HDZero VTX low band L1-L8. Same frequencies as Diatone / D band (5362 + 37 MHz steps),
+        // kept as its own group so a race can mix HDZero and analogue ground stations.
+        public static Channel[] HDZeroLowBand = new Channel[] {
+            HDZero[10],
+            HDZero[11],
+            HDZero[12],
+            HDZero[13],
+            HDZero[14],
+            HDZero[15],
+            HDZero[16],
+            HDZero[17],
         };
 
         public static Channel[] HDZeroRace = new Channel[] {
@@ -443,12 +464,13 @@ namespace RaceLib
                             return FrequencyLookup(Band.Raceband, prefix, channel);
                         case 'F': 
                             return FrequencyLookup(Band.Fatshark, prefix, channel);
+                        case 'L':
+                            return FrequencyLookup(Band.Diatone, prefix, channel);
                     }
                     break;
 
                 case Band.LowBand:
-                    // Matches HDZero VTX V3 firmware L1-L8 (5362, 5399 ... 5621, 37 MHz spacing)
-                    return 5362 + ((channel - 1) * 37);
+                    return 5333 + ((channel - 1) * 40);
                 case Band.Diatone:
                     return 5362 + ((channel - 1) * 37);
 

--- a/RaceLib/Channel.cs
+++ b/RaceLib/Channel.cs
@@ -133,6 +133,12 @@ namespace RaceLib
         {
             if (Band == Band.None) return "--";
 
+            // HDZero low band reads as plain L1-L8 on screen, matching the VTX/goggle menus.
+            if (Band == Band.HDZero && ChannelPrefix == 'L')
+            {
+                return ChannelPrefix + Number.ToString();
+            }
+
             if (ChannelPrefix != char.MinValue)
             {
                 string outa = Band.GetCharacter() + ChannelPrefix + Number.ToString();

--- a/UI/Nodes/ObjectEditorNode.cs
+++ b/UI/Nodes/ObjectEditorNode.cs
@@ -363,6 +363,7 @@ namespace UI.Nodes
                 { "HDZero", Channel.HDZero },
                 { "HDZero Race", Channel.HDZeroRace },
                 { "HDZero IMD6C", Channel.HDZeroIMD6C },
+                { "HDZero Low Band", Channel.HDZeroLowBand },
                 { "DJI", Channel.DJIFPVHD },
                 { "DJIO3", Channel.DJIO3 },
                 { "DJIO4", Channel.DJIO4 },


### PR DESCRIPTION
## Summary
Adds HDZero's low band (**L1–L8**) to FPVTrackside as its own set of channels, alongside the existing D (Diatone) and L (LowBand) bands, which are left exactly as they are.

> **Revised after feedback** — the first cut of this PR retuned `Band.LowBand` to the HDZero frequencies. Reviewer feedback was to keep D and L as-is and add HDZero low band as an *addition* (the same way `HDZero R1–R8` sit next to `Raceband R1–R8`) so dual-groundstation setups keep working — e.g. an analogue ClearView on D band paired with HDZero event receivers on the same frequencies. This is now what the PR does. The net diff against master is purely additive.

## What's added
HDZero VTX V3 firmware defines its low band L1–L8 as **5362, 5399, 5436, 5473, 5510, 5547, 5584, 5621** MHz (5362 + 37 MHz steps) — the same eight frequencies as FPVTrackside's existing `Band.Diatone`.

| Ch | Text | Freq (MHz) | Same as |
|---|---|---|---|
| L1 | `L1` | 5362 | D1 |
| L2 | `L2` | 5399 | D2 |
| L3 | `L3` | 5436 | D3 |
| L4 | `L4` | 5473 | D4 |
| L5 | `L5` | 5510 | D5 |
| L6 | `L6` | 5547 | D6 |
| L7 | `L7` | 5584 | D7 |
| L8 | `L8` | 5621 | D8 |

- The channels live in `Band.HDZero` with prefix `'L'` (IDs 82–89), following the existing `ZR1`/`ZF2` pattern, so `GetBandType()` reports `HDZeroDigital` for them with no extra wiring. On screen (pilot tiles, RSSI panel, channel lists) they read as plain **`L1`–`L8`**, matching the HDZero VTX/goggle menus; the long form is `HDZero L1 (5362MHz)`.
- New `Channel.HDZeroLowBand` array, and an **"HDZero Low Band"** entry in the channel-set picker next to "HDZero Race" / "HDZero IMD6C".
- Frequencies come from `FrequencyLookup(Band.Diatone, …)` so they can't drift from D band.
- `Band.LowBand` and `Band.Diatone` are unchanged.

## Why this matters
FPVTrackside pushes each pilot's channel frequency to the timing system (`RotorHazardTimingSystem.SetListeningFrequencies` → `ts_frequency_setup`). Until now the only way to get an HDZero low-band pilot timed was to assign them a D-band (Diatone) channel, which works for RSSI but mislabels them as analogue. With this change they can be assigned HDZero `L1–L8`: RotorHazard is tuned to the right MHz *and* the channel is correctly typed as HDZero digital.

## HDZero references
- Official HDZero docs — Low Band channel table (L1–L8 → 5362 … 5621): https://docs.hd-zero.com/goggles-operation
- HDZero VTX firmware — `FREQ_L1`…`FREQ_L8`: https://github.com/hd-zero/hdzero-vtx/blob/ad396315680f64ad5797fb0fe53bbd73e9f448ba/src/common.h#L188-L195
- HDZero VTX user manual: https://hd-zero.github.io/hdzero-vtx-docs/latest/vtx_user_manual/

## Change
`RaceLib/Channel.cs` (+8 channels, `HDZeroLowBand` group, `'L'` prefix in `FrequencyLookup`) and `UI/Nodes/ObjectEditorNode.cs` (+1 picker entry).

## Test plan
- [x] `dotnet build RaceLib` and `dotnet build UI` clean
- [x] Verified HDZero L1–L8 frequencies equal D1–D8, display as `L1`–`L8`, band type is `HDZeroDigital`, all channel IDs still unique, `GetChannel(Band.HDZero, n, 'L')` resolves, and L/D band frequencies are unchanged
