### PR TITLE
fix(aruco): stop duplicate detection threads and the phantom laps they produce

### DIFF
--- a/Timing/Aruco/ArucoTimingSystem.cs
+++ b/Timing/Aruco/ArucoTimingSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using OpenCvSharp;
@@ -160,6 +161,10 @@ namespace Timing.Aruco
             public bool InGate;
             public DateTime FlickerEndTime = DateTime.MinValue;
             public int LastPeak;
+
+            // Time of the last crossing reported for this channel. Used to guarantee the times we
+            // hand to RaceLib never repeat or go backwards - see ReportMarkerCount.
+            public DateTime LastDetectionTime = DateTime.MinValue;
         }
 
         public bool Connect() => true;
@@ -186,13 +191,23 @@ namespace Timing.Aruco
 
         public bool StartDetection(ref DateTime time, StartMetaData startMetaData)
         {
+            // Snapshot under stateLock, then take each channel lock separately. Never hold both at
+            // once: ReportMarkerCount raises OnDetectionEvent while holding a channel lock, so a
+            // stateLock -> channel lock nesting here could deadlock against it.
+            ChannelState[] states;
             lock (stateLock)
             {
-                foreach (var s in stateByFreq.Values)
+                states = stateByFreq.Values.ToArray();
+            }
+
+            foreach (var s in states)
+            {
+                lock (s)
                 {
                     s.InGate = false;
                     s.FlickerEndTime = DateTime.MinValue;
                     s.LastPeak = 0;
+                    s.LastDetectionTime = DateTime.MinValue;
                 }
             }
             detecting = true;
@@ -223,25 +238,50 @@ namespace Timing.Aruco
                     return;
             }
 
-            if (count >= markerThreshold)
+            // The whole state machine runs under the channel's own lock, not just the dictionary
+            // lookup above. InGate / FlickerEndTime are read-modify-written here, so an unlocked
+            // version lets two callers both pass the FlickerEndTime check before either clears
+            // InGate, emitting two crossings for a single gate pass. RaceLib cannot recover from
+            // that: Race.RecordLap looks for the previous lap with a strict "Detection.Time <"
+            // filter, so a duplicate carrying an identical or slightly earlier timestamp skips the
+            // lap it duplicates and gets measured from the one before it. The result is a
+            // full-length copy of a real lap that passes both RecordLap's <1ms guard and
+            // Lapalyser's MinLapTime check, handing the pilot a lap they never flew.
+            //
+            // The event is raised inside the lock deliberately: it is already raised synchronously
+            // on the caller's thread, and releasing first would let a preempted caller deliver an
+            // older detectionTime after a newer one - reintroducing the inversion this guards
+            // against. Contention is limited to callers reporting the same channel.
+            lock (state)
             {
-                state.InGate = true;
-                state.LastPeak = peak;
-                state.FlickerEndTime = DateTime.MinValue;
-                return;
-            }
+                if (count >= markerThreshold)
+                {
+                    state.InGate = true;
+                    state.LastPeak = peak;
+                    state.FlickerEndTime = DateTime.MinValue;
+                    return;
+                }
 
-            if (!state.InGate) return;
+                if (!state.InGate) return;
 
-            if (state.FlickerEndTime == DateTime.MinValue)
-                state.FlickerEndTime = captureTime.AddMilliseconds(flickerLengthMs);
+                if (state.FlickerEndTime == DateTime.MinValue)
+                    state.FlickerEndTime = captureTime.AddMilliseconds(flickerLengthMs);
 
-            if (captureTime >= state.FlickerEndTime)
-            {
+                if (captureTime < state.FlickerEndTime) return;
+
                 DateTime detectionTime = captureTime.AddMilliseconds(-flickerLengthMs);
-                OnDetectionEvent?.Invoke(this, frequency, detectionTime, state.LastPeak);
+
                 state.InGate = false;
                 state.FlickerEndTime = DateTime.MinValue;
+
+                // Never report a time at or before the previous crossing on this channel. Detection
+                // times are derived from the caller's captureTime, so anything that makes those
+                // non-monotonic - a second detection thread, or an OS clock step - would otherwise
+                // reach RaceLib as an out-of-order lap.
+                if (detectionTime <= state.LastDetectionTime) return;
+                state.LastDetectionTime = detectionTime;
+
+                OnDetectionEvent?.Invoke(this, frequency, detectionTime, state.LastPeak);
             }
         }
     }

--- a/UI/Video/ArucoTimingManager.cs
+++ b/UI/Video/ArucoTimingManager.cs
@@ -36,6 +36,7 @@ namespace UI.Video
 
         private volatile bool run;
         private Thread thread;
+        private volatile bool disposed;
 
         // FrameNodeThumb.renderTarget is private; we invalidate it via reflection after
         // enlarging Size, so PreProcess re-creates the RenderTarget at the new size.
@@ -53,11 +54,29 @@ namespace UI.Video
 
         public void Dispose()
         {
+            // Unsubscribe before cleaning up. ChannelsGridNode.InitVideoTimingSystems() disposes
+            // this instance and creates a replacement every time the Video Input Settings dialog
+            // closes (OK *and* Cancel both reach it via EventLayer's VideoSettingsExited handler).
+            // Without this the disposed instance stayed subscribed to OnInitialise, so the next
+            // InitialiseTimingSystems - e.g. pressing OK in Timing Settings - called Init() on it
+            // and restarted its detection thread. Every extra Video Input Settings round trip
+            // added another one, all driving the same ArucoTimingSystem.ChannelState from
+            // separate threads with independently sampled captureTimes.
+            disposed = true;
+            if (timingSystemManager != null)
+            {
+                timingSystemManager.OnInitialise -= Init;
+            }
             CleanUp();
         }
 
         public void Init()
         {
+            // A disposed instance must never resurrect its thread, even if something still holds
+            // a reference and re-raises OnInitialise.
+            if (disposed)
+                return;
+
             CleanUp();
 
             // Probe (and log) native availability up front so we always see the result, even when


### PR DESCRIPTION
## Summary

Fixes a bug in ArUco timing where a single gate pass is recorded as two laps, crediting a pilot with laps they never flew. In a real race this decided the finishing order incorrectly.

## Symptom

In a 3 lap race (holeshot enabled), one pilot's lap row read:

<img width="439" height="80" alt="failure" src="https://github.com/user-attachments/assets/c6df6de2-6b05-46c1-ab7e-63d4b1de0241" />

```
HS 2.38 | L2 34.41 | L1 34.41 | L4 13.90 | L3 13.90
```

Two things are wrong here.

1. **Two pairs of duplicated laps.** The chips add up to 99.00 s, but this pilot's last gate pass was at 50.69 s into the race - physically impossible. What they actually flew is HS 2.38 + 34.41 + 13.90 = 50.69 s, i.e. **two laps only**.
2. **Each pair is in reverse order** (L2 before L1, L4 before L3). `LapsNode` sorts by `End` (= `Detection.Time`), so the lap that received the *higher* number has the *earlier* detection time, by a few milliseconds.

As a result this pilot was declared to have completed 3 laps after flying only 2. Another pilot in the same race showed the same pattern on their final lap.

## Cause

### 1. Detection threads are started more than once (`ArucoTimingManager`)

`Dispose()` never unsubscribed from `timingSystemManager.OnInitialise`.

`ChannelsGridNode.InitVideoTimingSystems()` disposes the existing instance and replaces it with a new one, but the disposed instance stays subscribed. The next time `InitialiseTimingSystems()` runs, `Init()` is called on the disposed instance too and it restarts its detection thread.

Steps to reproduce:

1. Start the app and open an event (manager #1)
2. Open **Video Input Settings** and close it - #1 is disposed but stays subscribed, and #2 is created
   (both `OnOK` *and* `OnCancel` raise `VideoSettingsExited`, and the handler calls `LoadVideo()` without looking at the argument, so Cancel is enough)
3. Open **Timing Settings** and press **OK** - `OnInitialise` fires, both #1 and #2 run `Init()`, giving **two detection threads**

Every additional Video Input Settings round trip adds another thread. Because `InitVideoTimingSystems()` is a method on the grid itself and the grid is not disposed, the leftover instance keeps looking at exactly the same channels and the same `ArucoTimingSystem` objects as the new one.

### 2. `ReportMarkerCount` is not thread safe

`stateLock` only guards the dictionary lookup; the read-modify-writes of `InGate` and `FlickerEndTime` are unprotected. This is a textbook check-then-act race: two callers can both pass the `captureTime >= FlickerEndTime` check before either clears `InGate`, so **one gate pass raises `OnDetectionEvent` twice**.

On top of that the detection time is `captureTime - flickerLengthMs`, where `captureTime` is a `DateTime.Now` sampled independently by each thread. The caller that fires second can therefore carry the *older* timestamp, which is what produces the reversed ordering in the display.

### 3. RaceLib cannot absorb it

`Race.RecordLap` looks for the previous lap with a strict `l.Detection.Time < detection.Time` filter. A duplicate carrying an identical or slightly earlier timestamp therefore **skips the lap it duplicates and is measured from the one before it**. Instead of a zero length lap, the result is a full length copy of a real lap, which passes both existing safety nets:

- the "shorter than 1 ms is invalid" check in `RecordLap` (34410 ms, so it passes)
- `Lapalyser`'s automatic `MinLapTime` disqualification (5 s by default, 34.41 s passes)

Walking that path reproduces the observed display exactly:


| Real gate pass | Detection | Lap number assigned | Measured from | Length |
|---|---|---|---|---|
| HS @2.38 | single | 0 (HS) | race start | 2.38 |
| lap 1 @36.79 | first to arrive | L1 | HS | 34.41 |
| same pass (duplicate, a few ms earlier) | second to arrive | L2 | HS | 34.41 |
| lap 2 @50.69 | first to arrive | L3 | L1 | 13.90 |
| same pass (duplicate, a few ms earlier) | second to arrive | L4 | L1 | 13.90 |

Sorted by `End` this gives `HS, L2, L1, L4, L3`, matching the screenshot.

## Changes

Kept entirely inside ArUco - RaceLib and the other timing systems are untouched.

**`UI/Video/ArucoTimingManager.cs`**

- `Dispose()` now unsubscribes from `OnInitialise`
- Added a `disposed` flag that makes `Init()` a no-op on a disposed instance, so its thread cannot come back even if something still holds a reference

**`Timing/Aruco/ArucoTimingSystem.cs`**

- The whole state machine now runs under the channel's own lock. A gate pass fires exactly once; a second caller returns early on `InGate == false`
- Added `ChannelState.LastDetectionTime` and drop any detection time at or before the previous one. Besides duplicate threads this also stops an OS clock step from reaching RaceLib as an out-of-order lap
- `OnDetectionEvent` is raised inside the lock, deliberately. Releasing first would let a preempted caller deliver an older detection time after a newer one, reintroducing the inversion this guards against. It was already raised synchronously, so the blocking behaviour is unchanged
- Removed the nested locking in `StartDetection`: it now snapshots under `stateLock` and takes each channel lock outside it. Since `ReportMarkerCount` hands control to RaceLib while holding a channel lock, a `stateLock` -> channel lock ordering here left room for a deadlock

## Verification

The repro for cause 1 (open and close Video Input Settings, then open ArUco) was run on real hardware against builds from both sides of the fix.

| Build | Steps | Result |
|---|---|---|
| Before the fix (`master`) | Open ArUco after opening and closing Video Input Settings | Fails (duplicate detection reproduces) |
| After the fix (`fix/aruco-duplicate-detection`) | Same steps | Does not reproduce |

On the fixed build the detection thread stays single even across an open/close of Video Input Settings, and one gate pass records exactly one lap.