### PR TITLE
Preserve and restore race results during data refresh

### DIFF
--- a/RaceLib/EventManager.cs
+++ b/RaceLib/EventManager.cs
@@ -383,8 +383,7 @@ namespace RaceLib
 
             workQueue.Enqueue(workSet, "Unloading Results", () =>
             {
-                // Load points
-                ResultManager.Clear();
+                ResultManager.Unload();
             });
 
             workQueue.Enqueue(workSet, "Unloading Records", () =>

--- a/RaceLib/ResultManager.cs
+++ b/RaceLib/ResultManager.cs
@@ -909,6 +909,45 @@ namespace RaceLib
             }
         }
 
+        public void Unload()
+        {
+            lock (Results)
+            {
+                Results.Clear();
+            }
+        }
+
+        public int RecalculateMissingRaceResults()
+        {
+            HashSet<Guid> racesWithResults;
+            lock (Results)
+            {
+                racesWithResults = Results
+                    .Where(result => result.Race != null)
+                    .Select(result => result.Race.ID)
+                    .ToHashSet();
+            }
+
+            Race[] missingResults = EventManager.RaceManager.GetRaces(race =>
+                race.Valid &&
+                race.Ended &&
+                race.Round != null &&
+                race.Round.EventType.HasResult() &&
+                race.PilotCount > 0 &&
+                !racesWithResults.Contains(race.ID));
+
+            int recalculated = 0;
+            foreach (Race race in missingResults)
+            {
+                if (SaveResults(race))
+                {
+                    recalculated++;
+                }
+            }
+
+            return recalculated;
+        }
+
         public void Recalculate(Round endRound)
         {
             Round start = GetStartRound(endRound);

--- a/UI/Nodes/MenuButton.cs
+++ b/UI/Nodes/MenuButton.cs
@@ -338,6 +338,11 @@ namespace UI.Nodes
                     eventManager.UnloadRaces(workSet, ll.WorkQueue);
                     eventManager.LoadRaces(workSet, ll.WorkQueue);
 
+                    ll.WorkQueue.Enqueue(workSet, "Recalculating Missing Results", () =>
+                    {
+                        eventManager.ResultManager.RecalculateMissingRaceResults();
+                    });
+
                     ll.WorkQueue.Enqueue(workSet, "Refreshing UI", () =>
                     {
                         DataDeleted?.Invoke();


### PR DESCRIPTION
## Summary

- unload cached race results without deleting their persisted JSON data
- rebuild results only for completed, valid races that have no stored results
- leave every race with existing result data untouched

## Background

This was noticed while reviewing race data from the MultiGP Greater Central America Regional Finals in Queretaro, Mexico. Round 1 and Round 2 initially showed the expected position or DNF labels for each race. After selecting **Refresh all race data**, the lap-record view refreshed correctly, but the per-race result labels disappeared.

Inspection of a read-only copy of the event showed that the race and lap data remained intact while completed-race Result.json files had been replaced with empty arrays. A separate test event reproduced the loss: R2R14 contained four DNF results before refresh, and the production build removed them during refresh.

## Cause

EventManager.UnloadRaces() called ResultManager.Clear(). That method deletes every loaded result through the database before clearing the in-memory list, so the following load could only read empty result files.

## Fix

- add a memory-only ResultManager.Unload() method and use it during refresh
- after reloading, identify completed result-bearing races with pilots but no stored result entries
- regenerate only those missing race results through the existing SaveResults() path
- preserve nonempty result files, including manual result overrides

The affected manager and menu code are shared by Windows, macOS, and Linux.

## Verification

- dotnet build FPVMacSideCore/FPVMacsideCore.csproj --configuration Debug --no-restore completed with 0 errors
- damaged fixture baseline: 31 result files, 30 empty, R2R14 containing four DNF entries
- first refresh: all 31 files nonempty with 120 total result entries
- R2R14 SHA-256 remained unchanged after recovery
- second refresh: checksums for all 31 result files remained unchanged
- labels remained visible in FPVMacSide after both refreshes

## Recovery note

Missing results are reconstructed from the intact race and lap data. Manual overrides that were already deleted cannot be inferred, but any result file that still contains data is deliberately left untouched.