### PR TITLE
Load pilot profile pictures automatically

### DIFF
--- a/RaceLib/EventManager.cs
+++ b/RaceLib/EventManager.cs
@@ -183,9 +183,9 @@ namespace RaceLib
                 db.Update(eventObj);
             }
 
-            OnPilotRefresh?.Invoke();
-
             ProfilePictures.FindProfilePicture(pc.Pilot);
+
+            OnPilotRefresh?.Invoke();
 
             return true;
         }

--- a/RaceLib/ProfilePictures.cs
+++ b/RaceLib/ProfilePictures.cs
@@ -64,11 +64,12 @@ namespace RaceLib
                         {
                             // macOS stores file names decomposed (NFD), so both sides are
                             // brought to NFC before comparing. The matched FileInfo keeps
-                            // the on-disk name for the actual file access.
+                            // the on-disk name for the actual file access. Case is ignored
+                            // so "john smith.jpg" still matches a pilot named "John Smith".
                             string pilotName = p.Name.NormaliseUnicode();
                             IEnumerable<FileInfo> matches = media.Where(f =>
                                 Path.GetFileNameWithoutExtension(f.Name).NormaliseUnicode()
-                                    .Equals(pilotName, StringComparison.Ordinal));
+                                    .Equals(pilotName, StringComparison.OrdinalIgnoreCase));
                             if (matches.Any())
                             {
                                 p.PhotoPath = matches

--- a/RaceLib/ProfilePictures.cs
+++ b/RaceLib/ProfilePictures.cs
@@ -11,7 +11,7 @@ namespace RaceLib
 {
     public class ProfilePictures
     {
-        private string[] extensions = new string[] { ".mp4", ".wmv", ".mkv", ".png", ".jpg" };
+        private string[] extensions = new string[] { ".mp4", ".wmv", ".mkv", ".png", ".jpg", ".jpeg" };
 
         private Guid EventId;
 
@@ -28,7 +28,7 @@ namespace RaceLib
             {
                 foreach (FileInfo file in pilotProfileDirectory.GetFiles())
                 {
-                    if (extensions.Contains(file.Extension))
+                    if (extensions.Contains(file.Extension, StringComparer.OrdinalIgnoreCase))
                     {
                         yield return file;
                     }
@@ -60,17 +60,21 @@ namespace RaceLib
                 {
                     try
                     {
-                        string oldPath = p.PhotoPath;
                         if (string.IsNullOrEmpty(p.PhotoPath))
                         {
                             // macOS stores file names decomposed (NFD), so both sides are
                             // brought to NFC before comparing. The matched FileInfo keeps
                             // the on-disk name for the actual file access.
-                            string pilotName = p.Name.NormaliseUnicode().ToLower();
-                            IEnumerable<FileInfo> matches = media.Where(f => f.Name.NormaliseUnicode().ToLower().Contains(pilotName));
+                            string pilotName = p.Name.NormaliseUnicode();
+                            IEnumerable<FileInfo> matches = media.Where(f =>
+                                Path.GetFileNameWithoutExtension(f.Name).NormaliseUnicode()
+                                    .Equals(pilotName, StringComparison.Ordinal));
                             if (matches.Any())
                             {
-                                p.PhotoPath = matches.OrderByDescending(f => listOfExt.IndexOf(f.Extension)).FirstOrDefault().FullName;
+                                p.PhotoPath = matches
+                                    .OrderByDescending(f => listOfExt.FindIndex(extension =>
+                                        extension.Equals(f.Extension, StringComparison.OrdinalIgnoreCase)))
+                                    .FirstOrDefault().FullName;
                             }
                         }
                         if (!string.IsNullOrEmpty(p.PhotoPath))

--- a/UI/Nodes/ChannelNodeBase.cs
+++ b/UI/Nodes/ChannelNodeBase.cs
@@ -589,6 +589,13 @@ namespace UI.Nodes
 
             pilotProfileOptions = options;
 
+            // Don't do the small option if we're not a video node.
+            if (GetType() == typeof(ChannelNodeBase))
+            {
+                options = PilotProfileOptions.Large;
+                snap = true;
+            }
+
             if (!PilotProfile.HasProfileImage)
             {
                 options = PilotProfileOptions.None;

--- a/UI/Nodes/ChannelNodeBase.cs
+++ b/UI/Nodes/ChannelNodeBase.cs
@@ -576,6 +576,8 @@ namespace UI.Nodes
         {
             bool snap = false;
 
+            PilotProfile.EnsureLoaded();
+
             if (!force && options != PilotProfileOptions.None)
             {
                 if (ApplicationProfileSettings.Instance.AlwaysSmallPilotProfile || AlwaysSmallPilotProfile)
@@ -586,13 +588,6 @@ namespace UI.Nodes
             }
 
             pilotProfileOptions = options;
-
-            // Don't do the small option if we're not a video node.
-            if (GetType() == typeof(ChannelNodeBase))
-            {
-                options = PilotProfileOptions.Large;
-                snap = true;
-            }
 
             if (!PilotProfile.HasProfileImage)
             {

--- a/UI/Nodes/ChannelsGridNode.cs
+++ b/UI/Nodes/ChannelsGridNode.cs
@@ -86,6 +86,7 @@ namespace UI.Nodes
         private DateTime reOrderRequest;
 
         private bool extrasVisible;
+        private PilotProfileOptions pilotProfileOptions = PilotProfileOptions.Small;
 
         public event Action<Node> OnFullScreen;
 
@@ -458,6 +459,7 @@ namespace UI.Nodes
             if (channelNodeBase != null)
             {
                 channelNodeBase.SetPilot(pilotChannel.Pilot);
+                channelNodeBase.SetProfileVisible(pilotProfileOptions);
                 channelNodeBase.SetAnimationTime(CurrentAnimationTime);
                 channelNodeBase.SetAnimatedVisibility(true);
                 channelNodeBase.SetCrashedOutType(CrashState.AutoUp);
@@ -485,13 +487,7 @@ namespace UI.Nodes
 
         public void OnRaceManagerAddPilot(PilotChannel pilotChannel)
         {
-            ChannelNodeBase[] ps = AddPilots(pilotChannel);
-
-            foreach (ChannelNodeBase p in ps)
-            {
-                // Set this again incase changing the pilot has changed things.
-                p.SetProfileVisible(PilotProfileOptions.Large);
-            }
+            AddPilots(pilotChannel);
         }
 
         public ChannelNodeBase[] AddPilots(params PilotChannel[] pilotChannels)
@@ -670,6 +666,8 @@ namespace UI.Nodes
 
         public void SetProfileVisible(PilotProfileOptions options)
         {
+            pilotProfileOptions = options;
+
             foreach (ChannelNodeBase channelNode in ChannelNodes)
             {
                 channelNode.SetProfileVisible(options);

--- a/UI/Nodes/PilotProfileNode.cs
+++ b/UI/Nodes/PilotProfileNode.cs
@@ -114,13 +114,18 @@ namespace UI.Nodes
 
         public override void Layout(RectangleF parentBounds)
         {
-            if (needsLoadAttempt)
-            {
-                LoadProfile();
-                needsLoadAttempt = false;
-            }
+            EnsureLoaded();
 
             base.Layout(parentBounds);
+        }
+
+        public void EnsureLoaded()
+        {
+            if (!needsLoadAttempt || CompositorLayer == null)
+                return;
+
+            LoadProfile();
+            needsLoadAttempt = false;
         }
 
         private void LoadProfile()
@@ -182,7 +187,7 @@ namespace UI.Nodes
                         maskFilename = Theme.Current.PilotProfileMask.TextureFilename;
                     }
 
-                    if (videoFileTypes.Contains(fileInfo.Extension))
+                    if (videoFileTypes.Contains(fileInfo.Extension, StringComparer.OrdinalIgnoreCase))
                     {
                         CachedTextureFrameSource source = null;
 
@@ -226,7 +231,7 @@ namespace UI.Nodes
                         PilotPhoto = videoPlayer;
                         insideOutBorderRelativeNode.AddChild(PilotPhoto, 0);
                     }
-                    else if (imageFileTypes.Contains(fileInfo.Extension))
+                    else if (imageFileTypes.Contains(fileInfo.Extension, StringComparer.OrdinalIgnoreCase))
                     {
                         if (string.IsNullOrEmpty(maskFilename))
                         {


### PR DESCRIPTION
## Summary

- Automatically associate profile media from the `pilots` directory when the filename stem exactly matches the pilot name.
- Keep matching case-sensitive while normalizing Unicode filenames for macOS compatibility.
- Preserve existing, explicitly assigned profile paths.
- Load profile media before its first display so staged races do not initially show empty pilot boxes.
- Preserve the scene-requested profile size: large during staging, small after a click, at race start, and for completed races.
- Recognize `.jpeg` and mixed-case image/video extensions consistently in both discovery and rendering.

## Motivation

Profile media discovery previously used a case-insensitive substring match, so it could select similarly named files and still required manual intervention in common workflows. Profile media was also deferred until layout, which meant pictures often appeared only when the pilot announcement enlarged each box.

While validating eager loading, plain channel nodes were also found to force every small-profile request back to large. That prevented click-to-shrink and race-start transitions in configurations without an attached video source.

## Resulting behavior

- Loading an event or adding a pilot fills an empty profile path from an exact matching filename.
- A staged, unstarted race shows large profile pictures immediately.
- Clicking a large picture shrinks it to the banner icon.
- Starting a race shrinks all pictures to their banner positions.
- Completed races show small banner icons rather than full-window pictures.
- Existing non-empty profile assignments remain unchanged.

## Platforms

The changes are in the shared `RaceLib` and `UI` projects, so they apply to Windows, macOS, and Linux.

## Testing

- `dotnet build FPVMacSideCore/FPVMacsideCore.csproj --configuration Debug --no-restore` — succeeds with 0 errors.
- Manually tested on macOS using a copied event and test-only pilot images.
- Verified exact filename assignment during event load.
- Verified immediate display during staging, click-to-shrink, race-start shrinking, and small icons for completed races.
- Verified mixed-case extension rendering with `Revan_MX.PNG`.