### PR TITLE
Only show visible pilots lap markers on seek bar

### DIFF
--- a/UI/Video/ReplayNode.cs
+++ b/UI/Video/ReplayNode.cs
@@ -246,7 +246,7 @@ namespace UI.Video
             try
             {
                 CleanUp();
-                SeekNode.ClearFlags();
+                SeekNode.ClearRace();
 
                 this.race = race;
                 if (lap != null)
@@ -309,6 +309,8 @@ namespace UI.Video
                         cbn.LapsNode.OnAddLap = (pilot, time) => { EventManager.RaceManager.AddManualLapWithRace(race, pilot, time, 0); };
                         cbn.OnCloseClick += () => { Hide(cbn); };
                         cbn.OnCrashedOutClick += () => { Hide(cbn); };
+                        cbn.OnFullscreen += () => { FullScreen(cbn); };
+                        cbn.OnShowAll += () => { ShowAll(); };
 
                         cbn.AlwaysSmallPilotProfile = true;
                         cbn.SetProfileVisible(ChannelNodeBase.PilotProfileOptions.Small);
@@ -358,9 +360,22 @@ namespace UI.Video
             ChannelsGridNode.Reorder(true);
         }
 
+        private void FullScreen(ChannelNodeBase cbn)
+        {
+            // Only the full screened pilot's laps are of interest on the seek bar.
+            SeekNode.SetPilotFilter(cbn.Pilot);
+            SeekNode.ShowAll.Visible = true;
+        }
+
         private void ShowAll_OnClick(MouseInputEvent mie)
         {
+            ShowAll();
+        }
+
+        private void ShowAll()
+        {
             SeekNode.ShowAll.Visible = false;
+            SeekNode.SetPilotFilter(null);
 
             foreach (ChannelNodeBase cbn in ChannelsGridNode.ChannelNodes)
             {

--- a/UI/Video/SeekNode.cs
+++ b/UI/Video/SeekNode.cs
@@ -46,6 +46,12 @@ namespace UI.Video
 
         private EventManager eventManager;
 
+        private Race race;
+        private DateTime mediaStart;
+        private DateTime mediaEnd;
+
+        private Pilot filterPilot;
+
         public DateTime Start { get; set; }
         public DateTime End { get; set; }
 
@@ -100,6 +106,13 @@ namespace UI.Video
             progressBarLineContainer.ClearDisposeChildren();
         }
 
+        public void ClearRace()
+        {
+            ClearFlags();
+            race = null;
+            filterPilot = null;
+        }
+
         private DateTime FactorToTime(float factor)
         {
             TimeSpan length = End - Start;
@@ -116,15 +129,36 @@ namespace UI.Video
             return Math.Clamp(factor, 0, 1);
         }
 
+        // Limits the lap / game point markers to a single pilot. Null shows every pilot in the race.
+        public void SetPilotFilter(Pilot pilot)
+        {
+            if (filterPilot == pilot)
+                return;
+
+            filterPilot = pilot;
+
+            if (race != null)
+            {
+                SetRace(race, mediaStart, mediaEnd);
+            }
+        }
+
         public void SetRace(Race race, DateTime mediaStart, DateTime mediaEnd)
         {
             ClearFlags();
+
+            this.race = race;
+            this.mediaStart = mediaStart;
+            this.mediaEnd = mediaEnd;
 
             Start = race.Start > mediaStart ? mediaStart : race.Start;
             End = race.End < mediaEnd ? mediaEnd : race.End;
 
             foreach (PilotChannel pilotChannel in race.PilotChannelsSafe)
             {
+                if (filterPilot != null && pilotChannel.Pilot != filterPilot)
+                    continue;
+
                 Color tint = eventManager.GetRaceChannelColor(race, pilotChannel.Channel);
 
                 Lap[] laps = race.GetValidLaps(pilotChannel.Pilot, true);
@@ -158,6 +192,9 @@ namespace UI.Video
             {
                 foreach (GamePoint gamePoint in race.GamePoints)
                 {
+                    if (filterPilot != null && race.GetPilot(gamePoint.Channel) != filterPilot)
+                        continue;
+
                     Color tint = eventManager.GetRaceChannelColor(race, gamePoint.Channel);
 
                     AddTimeMarker(gamePoint.Time, tint, gamePoint.Channel.DisplayName);


### PR DESCRIPTION
Only show the visible pilots lap markers on seek bar in replay.

when you full screen on a pilot in replay the other pilots lap markers on the seek bar are hidden.

This helps a lot for long races with lots of laps, clearing up the seek bar when only reviewing one pilot