### PR TITLE
Halve startup time by loading only the active theme

### DIFF
--- a/Tools/IOTools.cs
+++ b/Tools/IOTools.cs
@@ -14,6 +14,23 @@ namespace Tools
     {
         public static DirectoryInfo WorkingDirectory { get; set; }
 
+        // Building an XmlSerializer emits and compiles a serialization assembly, so keep one per type.
+        private static readonly Dictionary<Type, XmlSerializer> xmlSerializerCache = new Dictionary<Type, XmlSerializer>();
+
+        private static XmlSerializer GetXmlSerializer<T>()
+        {
+            Type arrayType = typeof(T[]);
+            lock (xmlSerializerCache)
+            {
+                if (!xmlSerializerCache.TryGetValue(arrayType, out XmlSerializer serializer))
+                {
+                    serializer = new XmlSerializer(arrayType);
+                    xmlSerializerCache[arrayType] = serializer;
+                }
+                return serializer;
+            }
+        }
+
         /// <summary>
         /// Resolves a relative path to an absolute path based on WorkingDirectory.
         /// Absolute paths are returned as-is. Falls back to the current directory, as before,
@@ -145,7 +162,7 @@ namespace Tools
 
                 if (ext == ".xml")
                 {
-                    XmlSerializer serializer = new XmlSerializer(typeof(T[]));
+                    XmlSerializer serializer = GetXmlSerializer<T>();
                     using (TextReader reader = new StringReader(contents))
                     {
                         return (T[])serializer.Deserialize(reader);
@@ -195,7 +212,7 @@ namespace Tools
 
                     if (file.Extension.ToLower() == ".xml")
                     {
-                        XmlSerializer serializer = new XmlSerializer(typeof(T[]));
+                        XmlSerializer serializer = GetXmlSerializer<T>();
                         using (TextWriter writer = new StreamWriter(file.FullName))
                         {
                             serializer.Serialize(writer, items);

--- a/UI/Theme.cs
+++ b/UI/Theme.cs
@@ -136,118 +136,125 @@ namespace UI
             PilotProfileMask = null;
         }
 
-        public static List<Theme> Themes { get; private set; }
+        private static DirectoryInfo themesDir;
+        private static GraphicsDevice graphicsDeviceRef;
+        private static List<Theme> themes;
 
-        public static IEnumerable<Theme> Load(DirectoryInfo directoryInfo, GraphicsDevice graphicsDevice)
+        // Loading every theme is expensive (each one decodes its whole image set), and the only
+        // thing that needs the full list is the theme editor. Load them on demand.
+        public static List<Theme> Themes
         {
-            KeyValuePair<string, string>[] replacements = new KeyValuePair<string, string>[]
+            get
             {
-                new KeyValuePair<string, string>("PBPage", "InfoPanel"),
-            };
+                if (themes == null)
+                {
+                    themes = new List<Theme>();
+                    if (themesDir != null && graphicsDeviceRef != null)
+                    {
+                        themes.AddRange(LoadAll(themesDir, graphicsDeviceRef));
+                    }
+                }
+                return themes;
+            }
+            private set { themes = value; }
+        }
 
+        private static KeyValuePair<string, string>[] ThemeXmlReplacements = new KeyValuePair<string, string>[]
+        {
+            new KeyValuePair<string, string>("PBPage", "InfoPanel"),
+        };
 
+        private static Theme LoadFromDirectory(DirectoryInfo directory, GraphicsDevice graphicsDevice)
+        {
+            FileInfo themeFile = new FileInfo(Path.Combine(directory.FullName, "theme.xml"));
+            if (themeFile.Exists)
+            {
+                try
+                {
+                    Theme theme = IOTools.Read<Theme>(directory.FullName, themeFile.Name, ThemeXmlReplacements).FirstOrDefault();
+                    theme.Name = directory.Name;
+                    theme.Directory = directory;
+                    theme.Upgrade();
+                    theme.Repair();
+                    return theme;
+                }
+                catch
+                {
+                }
+            }
+
+            FileInfo theme2File = new FileInfo(Path.Combine(directory.FullName, "theme2.xml"));
+            if (theme2File.Exists)
+            {
+                try
+                {
+                    Theme2 theme2 = IOTools.Read<Theme2>(directory.FullName, theme2File.Name, ThemeXmlReplacements).FirstOrDefault();
+                    theme2.Name = directory.Name;
+                    theme2.Directory = directory;
+                    return theme2.ToTheme(graphicsDevice, new Theme());
+                }
+                catch
+                {
+                }
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<Theme> LoadAll(DirectoryInfo directoryInfo, GraphicsDevice graphicsDevice)
+        {
             foreach (DirectoryInfo directory in directoryInfo.GetDirectories("*"))
             {
-                FileInfo themeFile = new FileInfo(Path.Combine(directory.FullName, "theme.xml"));
-                if (themeFile.Exists)
-                {
-                    Theme theme;
-                    try
-                    {
-                        theme = IOTools.Read<Theme>(directory.FullName, themeFile.Name, replacements).FirstOrDefault();
-                        theme.Name = directory.Name;
-                        theme.Directory = directory;
-
-                        theme.Upgrade();
-                        theme.Repair();
-
-                        IOTools.Write(directory.FullName, themeFile.Name, theme);
-
-                    }
-                    catch
-                    {
-                        continue;
-                    }
-
+                Theme theme = LoadFromDirectory(directory, graphicsDevice);
+                if (theme != null)
                     yield return theme;
-                }
-
-                //if (directory.Name == "NewDark")
-                //{
-                //    Theme2 theme2 = new Theme2();
-                //    FileInfo theme2Fil2e = new FileInfo(directory.FullName + "/theme2.xml");
-                //    IOTools.Write(directory.FullName, theme2Fil2e.Name, theme2);
-                //}
-
-                FileInfo theme2File = new FileInfo(Path.Combine(directory.FullName,"theme2.xml"));
-                if (theme2File.Exists)
-                {
-                    Theme2 theme2;
-
-                    Theme theme = null;
-
-                    try
-                    {
-                        theme2 = IOTools.Read<Theme2>(directory.FullName, theme2File.Name, replacements).FirstOrDefault();
-                        theme2.Name = directory.Name;
-                        theme2.Directory = directory;
-
-                        IOTools.Write(directory.FullName, theme2File.Name, theme2);
-
-                        theme = theme2.ToTheme(graphicsDevice, new Theme());
-                    }
-                    catch
-                    {
-                        continue;
-                    }
-
-                    if (theme != null)
-                    {
-                        yield return theme;
-                    }
-                }
             }
         }
 
         public static void Initialise(GraphicsDevice gd, DirectoryInfo workingDirectory, string name)
         {
-            List<Theme> themes = new List<Theme>();
+            string targetName = ApplicationProfileSettings.Instance?.Theme ?? name;
 
-            DirectoryInfo themesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, "themes"));
+            if (Current != null && Current.Name == targetName)
+                return;
 
-            themes.AddRange(Load(themesDirectory, gd));
+            themesDir = new DirectoryInfo(Path.Combine(workingDirectory.FullName, "themes"));
+            graphicsDeviceRef = gd;
+            themes = null;
 
-            Themes = themes.ToList();
-
-            Theme oldCurrent = Current;
-
-            if (ApplicationProfileSettings.Instance != null)
+            if (themesDir.Exists)
             {
-                Current = Themes.FirstOrDefault(t => t.Name == ApplicationProfileSettings.Instance.Theme);
-            }
+                DirectoryInfo targetDir = new DirectoryInfo(Path.Combine(themesDir.FullName, targetName));
+                if (targetDir.Exists)
+                {
+                    Current = LoadFromDirectory(targetDir, gd);
+                }
 
-            if (Current == null)
-            {
-                Current = oldCurrent;
-            }
+                if (Current == null && targetName != name)
+                {
+                    targetDir = new DirectoryInfo(Path.Combine(themesDir.FullName, name));
+                    if (targetDir.Exists)
+                    {
+                        Current = LoadFromDirectory(targetDir, gd);
+                    }
+                }
 
-            if (Current == null)
-            {
-                Current = Themes.FirstOrDefault(t => t.Name == name);
-            }
+                if (Current == null)
+                {
+                    targetDir = new DirectoryInfo(Path.Combine(themesDir.FullName, "FPVTrackside"));
+                    if (targetDir.Exists)
+                    {
+                        Current = LoadFromDirectory(targetDir, gd);
+                    }
+                }
 
-            if (Current == null)
-            {
-                Current = Themes.FirstOrDefault(t => t.Name == "FPVTrackside");
-            }
-
-            if (Current == null)
-            {
-                Current = Themes.FirstOrDefault();
+                if (Current == null)
+                {
+                    Current = LoadAll(themesDir, gd).FirstOrDefault();
+                }
             }
 
             Logger.UI.LogCall(Current, "Theme.Init");
-
 
             if (Current == null)
             {
@@ -328,6 +335,9 @@ namespace UI
         {
             foreach (PropertyInfo propertyInfo in obj.GetType().GetProperties())
             {
+                if (propertyInfo.GetAccessors(true)[0].IsStatic)
+                    continue;
+
                 object value = propertyInfo.GetValue(obj, null);
                 if (value == null)
                     continue;
@@ -371,6 +381,11 @@ namespace UI
         {
             foreach (PropertyInfo propertyInfo in obj.GetType().GetProperties())
             {
+                // Theme's static properties (Current, Themes) are not part of a theme's own data,
+                // and reading Themes here would force every theme on disk to load.
+                if (propertyInfo.GetAccessors(true)[0].IsStatic)
+                    continue;
+
                 object value = propertyInfo.GetValue(obj, null);
                 if (value == null)
                     continue;


### PR DESCRIPTION
## Summary

Cuts cold-start time roughly in half. The app was reloading every installed theme three times on every launch, and rewriting all of the theme files back to disk each time.

## What was slow

`Theme.Initialise` loaded **every** theme directory — all nine ship with the app, about 8.9 MB of PNGs — even though only one is ever used. It also re-serialised and rewrote every `theme2.xml` back to disk on each call, and it was called three times per launch: from `FPVTracksideCoreGame.LoadContent`, from `BaseGame`'s "Loading Theme" work item, and from the `EventLayer` constructor.

## Changes

`UI/Theme.cs`:

- `LoadFromDirectory` loads a single named theme. `Initialise` resolves the configured theme → the caller's default name → `FPVTrackside` → first available, instead of materialising all of them and picking one.
- Early return when the requested theme is already current, so the second and third calls cost nothing.
- Removed the `IOTools.Write` write-back that re-serialised every theme file to disk on each call.
- `Themes` (the full list) is now loaded on demand — only the theme editor needs it.
- `LocaliseFilenames` and `AutoName` now skip static properties when walking `GetProperties()`, matching what `ForEach<T>` already did.

That last point is worth calling out, because without it the rest of the change achieves nothing. `GetProperties()` includes static properties by default, so both walkers were calling `GetValue` on `Theme.Themes`. Once that became a lazy loader, the reflection walk pulled every theme straight back in and the optimisation cancelled itself out — `LocaliseFilenames` alone measured 1085 ms. `Theme`'s only statics are `Current` and `Themes`, neither of which is a `ToolTexture` or panel theme, so nothing that was previously renamed or localised is skipped now.

`Tools/IOTools.cs`:

- Cache one `XmlSerializer` per type rather than constructing a new one on every read and write. Each construction emits and compiles a serialization assembly, and settings and theme files are read repeatedly during startup.

## Measurements

Release x64, warm launches, wall clock from process start to the event selector being on screen (taken from the `ShowEventSelector` log entry), nine themes installed:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before | 2.31 s | 2.24 s | 2.22 s |
| after | 1.33 s | 1.27 s | 1.26 s |

**About 0.97 s faster — 43% off time to first screen.**

Verified alongside the numbers:

- `Theme.Init` now appears once per launch in the log instead of three times.
- The nine `theme2.xml` files keep their timestamps across launches; previously every one was rewritten on every start.
- Loading into an event benefits too, since the second and third `Theme.Initialise` calls now return immediately rather than repeating the full load.

## Testing

- `dotnet build FPVTracksideCore/FPVTracksideCore.csproj -c Release -p:Platform=x64` — clean, no new warnings.
- Startup timings above: three runs each, before and after, same machine and same working directory, built from this branch with only these changes stashed and unstashed between the two sets.
- Confirmed the theme files are no longer rewritten, and that the app still starts on the configured theme with all nine themes installed.

Not covered by automated tests — the theme and startup paths need a real graphics device, so the verification above is manual.

## Risk notes

- Theme resolution order changed shape but keeps the same fallbacks. If the configured theme directory is missing, the previously loaded theme stays in use, as before.
- The theme editor still gets the full list; it just triggers the load itself the first time it is opened, which is a small one-off cost at that point instead of on every launch.
- Skipping statics in the reflection walkers is the only behavioural change to theme data handling, and it affects only `Theme.Current` and `Theme.Themes`, which were never valid targets for renaming or path localisation.