### PR TITLE
Scroll lap editor rows instead of shrinking lap times

### DIFF
--- a/UI/Nodes/LapEditorNode.cs
+++ b/UI/Nodes/LapEditorNode.cs
@@ -39,6 +39,8 @@ namespace UI.Nodes
 
         protected List<LapEditorContainer> lapContainers;
 
+        private LapRowListNode lapRows;
+
         protected IEnumerable<LapEditorContainer> orderedLapContainers { get { return lapContainers.OrderBy(l => l.End); } }
 
         public RaceManager RaceManager { get; private set; }
@@ -52,6 +54,12 @@ namespace UI.Nodes
         protected virtual RectangleF RaceNodeBounds => new RectangleF(0.01f, 0.09f, 0.98f, 0.1f);
         protected virtual RectangleF LapsNodeBounds => new RectangleF(0.01f, 0.22f, 0.98f, 0.65f);
         protected virtual float ButtonContainerTop => 1 - 0.10f;
+
+        // Grid sizing. Rows are a fixed height, so more laps scroll rather than shrinking
+        // every time down to nothing. Fewer columns and rows than the area could hold means
+        // each lap gets more room, which is what makes the times readable.
+        protected virtual int LapsPerRow => 6;
+        protected virtual int VisibleLapRows => 6;
 
         public LapEditorNode(RaceManager raceManager, Race race, Pilot pilot, IEnumerable<Lap> laps, Color channel)
         {
@@ -198,10 +206,19 @@ namespace UI.Nodes
                 lc.Remove();
             }
 
-            lapsNode.ClearDisposeChildren();
+            if (lapRows == null)
+            {
+                lapRows = new LapRowListNode(Theme.Current.ScrollBar.XNA);
+                lapRows.VisibleRows = VisibleLapRows;
+                lapRows.ItemPadding = 2;
+                lapsNode.AddChild(lapRows);
+            }
+            else
+            {
+                lapRows.ClearDisposeChildren();
+            }
 
-            int perRow = 8;
-            int rowCount = 8;
+            int perRow = LapsPerRow;
             List<Node> rows = new List<Node>();
 
             foreach (LapEditorContainer lc in orderedLapContainers)
@@ -219,10 +236,10 @@ namespace UI.Nodes
             foreach (Node row in rows)
             {
                 AlignHorizontally(0.01f, perRow, row.Children.ToArray());
-                lapsNode.AddChild(row);
+                lapRows.AddChild(row);
             }
 
-            AlignVertically(0.01f, Math.Max(rowCount, rows.Count) , rows.ToArray());
+            lapRows.RequestLayout();
         }
 
         protected void OnSplitLap(LapEditorContainer original, int splits)
@@ -371,6 +388,30 @@ namespace UI.Nodes
 
             OnOK?.Invoke(Laps);
             Dispose();
+        }
+    }
+
+    // A list of lap rows that keeps every row the same readable height no matter how many
+    // there are, scrolling once they overflow. ItemHeight is in pixels, so it is derived from
+    // the laid out height rather than fixed, to hold up across resolutions and dialog sizes.
+    public class LapRowListNode : ListNode<Node>
+    {
+        public int VisibleRows { get; set; }
+
+        public LapRowListNode(Color scrollColor)
+            : base(scrollColor)
+        {
+            VisibleRows = 6;
+        }
+
+        public override void Layout(RectangleF parentBounds)
+        {
+            RectangleF bounds = CalculateRelativeBounds(parentBounds);
+
+            int rows = Math.Max(1, VisibleRows);
+            ItemHeight = Math.Max(1, (int)(bounds.Height / rows) - ItemPadding);
+
+            base.Layout(parentBounds);
         }
     }
 


### PR DESCRIPTION
## Summary

The lap editor shrank every lap time to fit whatever it had to show, so a long race left the times too small to read. Rows are now a fixed height and scroll once they overflow, and each lap gets a bit more room.

## The problem

`Layout()` divided the laps area by the number of rows it needed:

```csharp
AlignVertically(0.01f, Math.Max(rowCount, rows.Count), rows.ToArray());
```

At 8 laps per row and 8 rows, anything past 64 laps just kept compressing. Nothing scrolled. A 123 lap race needs 16 rows, so every time was rendered at half the height it was designed for.

## Before / after

Both screenshots are the same 123 lap race.

### Before
<img width="953" height="345" alt="Screenshot 2026-08-31 195953" src="https://github.com/user-attachments/assets/57c6e067-ce2a-450f-9dbc-7db1ed6dc8f4" />

### After
<img width="936" height="591" alt="Screenshot 2026-08-31 195910" src="https://github.com/user-attachments/assets/e12ae6c0-93e5-4970-bd46-ac039846643b" />

## Changes

All in `UI/Nodes/LapEditorNode.cs`.

**Scrolling.** Rows now live in a `LapRowListNode` — a small `ListNode<Node>` subclass — instead of being stretched to fit the area. Rows keep a constant height and anything past the visible area scrolls, with the standard themed scrollbar and mouse wheel support. `ItemHeight` is derived from the laid out height in `Layout` rather than hard coded, so it holds up across resolutions and dialog sizes.

**Bigger times.** Font size here is driven by node height but capped by width when the text will not fit, so taller rows alone would only have half worked. Both dimensions changed: 8 → 6 laps per row and 8 → 6 visible rows, giving each lap about a third more room each way.

For the 123 lap race in the screenshots, rows go from a sixteenth of the area to a sixth — roughly 2.7 times taller.

Both numbers are `protected virtual`, sitting with the existing layout hooks, so they are easy to tune:

```csharp
protected virtual int LapsPerRow => 6;
protected virtual int VisibleLapRows => 6;
```

`MarshalEditorNode` inherits both. Its laps area is much shorter (0.295 vs 0.65 height), so it may want a lower `VisibleLapRows` later, but this change leaves it on the same values and it is no worse off than before.
